### PR TITLE
feat(spec): 將 admin-ui 和 worker 包含為活躍的子專案  

### DIFF
--- a/openspec/changes/multi-provider-key-harness/.openspec.yaml
+++ b/openspec/changes/multi-provider-key-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/multi-provider-key-harness/design.md
+++ b/openspec/changes/multi-provider-key-harness/design.md
@@ -1,0 +1,92 @@
+## Overview
+
+本變更以「Provider Adapter + Key Harness」為核心，將設定分成 **User Scope** 與 **Admin Scope**：
+- User Scope：使用者貼入 key 後，僅在該使用者 session 生效
+- Admin Scope：平台管理員維護全域預設 provider 設定，供未提供 user key 時使用
+
+系統維持既有業務流程，只替換底層模型呼叫層與設定治理邏輯。
+
+## Current Repo Mapping
+
+- 已在 monorepo：`projects/daodao-f2e`、`projects/daodao-server`、`projects/daodao-ai-backend`、`projects/daodao-storage`、`projects/daodao-admin-ui`、`projects/daodao-worker`
+
+## Architecture
+
+1. **User Harness Layer (`projects/daodao-f2e`)**
+   - Provider selector（OpenAI / Anthropic / Google ...）
+   - API key input（masked + paste）
+   - Session clear action
+
+2. **Admin Config Layer (`projects/daodao-admin-ui` + `projects/daodao-server`)**
+   - Default provider 設定
+   - Allowed models 白名單
+   - Fallback policy（primary/secondary provider）
+
+3. **Runtime Adapter Layer (`projects/daodao-ai-backend` + `projects/daodao-worker`)**
+   - `ProviderAdapter` 介面
+   - `OpenAIAdapter`, `AnthropicAdapter`, `GoogleAdapter`
+   - request/response normalization
+   - source-aware routing（user key 優先，否則 admin default）
+
+4. **Security Layer**
+   - user key 記憶體暫存（session scope）
+   - admin key 儲存於受保護祕密管理機制（不回傳前端）
+   - log redaction（永不輸出原始 key）
+   - TTL / clear action（離開或登出即清除 user key）
+
+5. **Quota & Billing Layer**
+   - admin quota policy（日/月上限、軟硬限制）
+   - user BYOK quota（由 provider 端實際限制）
+   - billing_source 標記（user/admin）
+
+6. **Observability Layer**
+   - metrics: provider, model, latency_ms, status, config_source(user/admin), billing_source(user/admin)
+   - error taxonomy: auth/quota/model/network/unknown
+
+## Routing Rules
+
+1. 若 user session 有有效 provider + key，走 user scope
+2. 否則走 admin 預設 provider 與政策
+3. 若 user key 無效或配額不足，依產品策略：
+   - 策略 A：回退到 admin quota（若管理員允許）
+   - 策略 B：直接回傳錯誤，要求使用者更新 key
+4. 若 admin primary 失敗且符合策略，切 secondary provider
+5. 每次請求都打上 `config_source` 與 `billing_source` 標記供追蹤
+
+## Data Flow
+
+1. 使用者在前端貼上 key（可選）
+2. 前端送出 provider + model + request（不持久化 key）
+3. Runtime 判斷 user scope 是否可用
+4. 可用則以 user key 初始化 adapter；否則載入 admin scope 設定
+5. adapter 呼叫供應商 API，回傳統一格式
+6. 記錄 metrics（不包含敏感資訊）
+
+## Security & Privacy
+
+- User key 不寫入資料庫（Phase 1）
+- Admin key 只能由後端祕密管理存取，禁止下發到 client
+- API key 不寫入 persistent logs
+- 回傳錯誤訊息經過 sanitize，避免外露 request payload
+- 嚴格 RBAC：只有 admin 角色可修改 admin scope 設定與配額政策
+
+## Rollout Plan
+
+- Phase 1: OpenAI + Anthropic adapter，User Harness（session key）
+- Phase 2: Admin Config UI + fallback policy
+- Phase 3: Google adapter + provider health check
+- Phase 4: 可選「加密暫存」與 per-user secure vault（需額外資安審查）
+
+## Risks
+
+- user/admin scope 與 quota 歸屬定義不清造成行為與成本混亂
+- 各供應商參數語義差異導致回應品質不一致
+- 錯誤碼 mapping 不完整造成 UX 不穩定
+- 若 key 被誤記錄到第三方監控會有資安風險
+
+## Mitigations
+
+- 明確定義 routing precedence 並加上 contract tests
+- 建立 adapter contract tests
+- 建立錯誤碼對照表與 fallback 文案
+- 對 logging middleware 做 redaction 單元測試與 CI gate

--- a/openspec/changes/multi-provider-key-harness/proposal.md
+++ b/openspec/changes/multi-provider-key-harness/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+目前團隊在測試 AI 功能時，常被單一供應商 API key 綁定，導致：
+- 無法快速切換不同模型供應商做比較
+- Demo 時受限於開發環境既有憑證
+- 測試與除錯流程難以重現（每個人本地 key 不同）
+
+需要一個可插拔的 harness，讓使用者貼上不同家的 API key 後即可立即使用同一套功能流程，降低整合與驗證成本。
+
+同時必須**明確區分兩種設定責任**：
+- **使用者端設定（User Scope）**：終端使用者自行貼上的 key，只影響自己的 session，且其用量/費用歸屬於使用者 key
+- **服務管理員設定（Admin Scope）**：平台管理員維護的 provider 預設設定與平台基礎額度，影響整個服務的 fallback 與治理
+
+## What Changes
+
+- 新增「Multi-provider key harness」能力：同一介面支援 OpenAI、Anthropic、Google 等供應商金鑰輸入與切換
+- 新增 provider 抽象層（adapter interface），統一 chat/completions 呼叫入口
+- 新增 key 驗證與錯誤分類（invalid key / quota exceeded / model not found）
+- 新增 session 層級 key 暫存策略（預設不落地）與安全清除機制
+- 新增最小可用觀測：provider、model、latency、error code
+- 新增雙軌設定模型：User Scope 與 Admin Scope 的欄位、權限與路由分離
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-key-harness-user-scope`: 使用者可貼入不同供應商 API key 並即時切換，僅作用於自己的 session
+- `provider-config-admin-scope`: 管理員可設定平台預設 provider、可用模型白名單與 fallback policy
+- `provider-adapter-runtime`: 以 adapter 方式統一供應商呼叫流程與參數映射
+- `credential-safety-guard`: key 輸入、暫存、清除與 redaction 安全防護
+- `provider-observability`: 基礎請求與錯誤指標追蹤（含 user/admin 來源標記）
+
+### Modified Capabilities
+
+- `ai-request-flow`: 既有 AI 呼叫流程改為透過 provider adapter 進行路由，不再硬編碼單一供應商
+
+## Quota & Usage Model
+
+- **平台基礎額度（Admin Quota）**：由管理員設定預設 provider 與月/日配額，供未提供 user key 的請求使用。
+- **使用者自帶額度（User BYOK Quota）**：使用者提供自己的 key 後，請求優先走 user key，使用量計入使用者 key，不占用平台基礎額度。
+- **回退策略**：若 user key 不可用（驗證失敗、配額不足、封鎖），依策略可選擇回退到 admin quota 或直接拒絕。
+- **可觀測性**：每筆請求記錄 `config_source` 與 `billing_source`（user/admin）以利對帳與治理。
+
+
+## Repository Grounding
+
+本規劃已對照目前 monorepo 結構（`projects/`）：
+- 已存在：`projects/daodao-f2e`、`projects/daodao-server`、`projects/daodao-ai-backend`、`projects/daodao-storage`、`projects/daodao-admin-ui`、`projects/daodao-worker`
+因此本 change 可直接在對應子專案落地，不需要以「規格保留」處理。
+
+## Impact
+
+- **前端（`projects/daodao-f2e`）**：新增使用者端 harness（provider 選擇、key 輸入、session 清除）。
+- **管理後台（`projects/daodao-admin-ui`）**：實作管理員設定頁（provider 預設值、白名單、fallback policy）。
+- **AI 服務（`projects/daodao-ai-backend`）**：新增 adapter 介面、provider client、錯誤映射與 source-aware metrics hook。
+- **後端 API（`projects/daodao-server`）**：新增 admin 設定 API 與 RBAC 控制。
+- **Worker（`projects/daodao-worker`）**：同步 edge 推理路徑的 user/admin 設定分流協議。
+- **安全性**：log 與 telemetry 禁止輸出完整 key；僅允許 masked 片段；admin 與 user 權限分離

--- a/openspec/changes/multi-provider-key-harness/tasks.md
+++ b/openspec/changes/multi-provider-key-harness/tasks.md
@@ -1,0 +1,47 @@
+## 1. Spec & Interface
+
+- [ ] 1.1 定義 `ProviderAdapter` 介面與標準請求/回應格式
+- [ ] 1.2 產出 provider capability matrix（支援模型、token 參數、streaming）
+- [ ] 1.3 定義錯誤 taxonomy 與 mapping 規格
+- [ ] 1.4 定義 user scope / admin scope 權限與 routing precedence 規格
+- [ ] 1.5 定義 quota 與 billing 歸屬規則（admin 基礎額度 / user BYOK 額度）
+
+## 2. Backend Runtime
+
+- [ ] 2.1 在 `daodao-ai-backend` 實作 OpenAIAdapter
+- [ ] 2.2 在 `daodao-ai-backend` 實作 AnthropicAdapter
+- [ ] 2.3 實作 adapter router（依 provider 動態分派）
+- [ ] 2.4 實作 source-aware routing（user key 優先，admin fallback）
+- [ ] 2.5 實作 key redaction 與 sanitize middleware
+- [ ] 2.6 實作 quota-aware routing（user quota -> optional admin fallback）
+
+## 3. User Harness (daodao-f2e)
+
+- [ ] 3.1 新增 provider selector 與 key input（session scope）
+- [ ] 3.2 新增 model selector（依 provider 動態更新）
+- [ ] 3.3 新增連線測試與錯誤提示 UX
+- [ ] 3.4 新增 clear key 動作與 session 結束清除流程
+
+## 4. Admin Config (`projects/daodao-admin-ui` + `projects/daodao-server`)
+
+- [ ] 4.1 在 `projects/daodao-server` 新增管理 API：default provider 設定
+- [ ] 4.2 在 `projects/daodao-server` 新增 allowed models 白名單設定
+- [ ] 4.3 在 `projects/daodao-server` 新增 fallback policy 設定（primary/secondary）
+- [ ] 4.4 在 `projects/daodao-server` 新增 RBAC 與審計欄位（誰在何時改了什麼）
+- [ ] 4.5 在 `projects/daodao-server` 新增 admin 基礎額度設定（日/月配額、回退是否允許）
+- [ ] 4.6 在 `projects/daodao-admin-ui` 實作對應管理頁與表單流程
+
+## 5. Tests
+
+- [ ] 5.1 為 adapter 共用邏輯建立單元測試（成功/失敗/timeout）
+- [ ] 5.2 為錯誤 mapping 建立 regression tests
+- [ ] 5.3 為 redaction middleware 建立安全測試（log 不含原始 key）
+- [ ] 5.4 為 routing precedence 建立測試（user scope vs admin scope）
+- [ ] 5.5 為 admin RBAC 建立權限測試
+- [ ] 5.6 為 quota 與 billing_source 建立測試（user/admin 計量分流）
+
+## 6. Observability & Rollout
+
+- [ ] 6.1 新增 provider/model/latency/error/config_source/billing_source 指標
+- [ ] 6.2 設定 feature flag，先內部開啟
+- [ ] 6.3 撰寫上線與回滾手冊


### PR DESCRIPTION
---  
## Why is this necessary?  
- 需要將 admin-ui 和 worker 子專案納入專案管理，以便於統一開發與維護。  
- 確保所有相關子專案的功能能夠正常運作，避免因為缺少子專案而導致的錯誤。  
- 提升專案的可擴展性，方便未來新增功能或模組。  

## How does it address?  
- 將 admin-ui 和 worker 設定為活躍的子專案，以便於在專案中進行管理。  
- 更新專案配置，使其能夠正確識別和使用這些子專案。  
- 確保所有開發人員都能夠輕鬆訪問和使用這些子專案，提升開發效率。  