### PR TITLE
fix(state): 修復 deriveState 的死分支以正確回退為 M 行為  

### DIFF
--- a/bin/routine-dispatch/__tests__/state.test.ts
+++ b/bin/routine-dispatch/__tests__/state.test.ts
@@ -119,6 +119,28 @@ describe("deriveState — standard dispatch", () => {
   });
 });
 
+describe("deriveState — no scope label (defaults to M behaviour)", () => {
+  it("no scope + auto:auto-pr → needs-spec (M default, no spec labels)", () => {
+    const state = deriveState("daodao-f2e", "30", labels("auto", "auto:auto-pr"));
+    expect(state).toBe("needs-spec");
+  });
+
+  it("no scope + auto:auto-pr + spec-merged → needs-code (M default, spec ready)", () => {
+    const state = deriveState("daodao-f2e", "31", labels("auto", "auto:auto-pr", "spec-merged"));
+    expect(state).toBe("needs-code");
+  });
+
+  it("no scope + auto:plan-only + spec-merged → stop-after-plan-done (M default, plan-only)", () => {
+    const state = deriveState("daodao-f2e", "32", labels("auto", "auto:plan-only", "spec-merged"));
+    expect(state).toBe("stop-after-plan-done");
+  });
+
+  it("no scope + auto:auto-pr + spec-pending → spec-in-review (M default)", () => {
+    const state = deriveState("daodao-f2e", "33", labels("auto", "auto:auto-pr", "spec-pending"));
+    expect(state).toBe("spec-in-review");
+  });
+});
+
 describe("deriveState — precedence ordering", () => {
   it("automation:hold takes precedence over human-driving", () => {
     const state = deriveState("daodao-f2e", "20", labels(

--- a/bin/routine-dispatch/state.ts
+++ b/bin/routine-dispatch/state.ts
@@ -104,12 +104,10 @@ export function deriveState(repo: string, issueNum: string, labels?: string[]): 
   // auto:plan-only or high-risk repo → plan-only path
   const isPlanOnly = autoMode === "plan-only" || isHighRisk;
 
-  if (!scope) {
-    // Default to M if no scope label
-    return isPlanOnly ? "needs-spec" : "needs-spec";
-  }
+  // No scope label defaults to M behaviour
+  const effectiveScope = scope ?? "M";
 
-  if (scope === "XS" || scope === "S") {
+  if (effectiveScope === "XS" || effectiveScope === "S") {
     // XS/S: single PR path
     // High-risk repos must never reach needs-code (defense-in-depth at state layer)
     if (isHighRisk) return "stop-after-plan-done";
@@ -117,7 +115,7 @@ export function deriveState(repo: string, issueNum: string, labels?: string[]): 
     return "needs-spec";
   }
 
-  if (scope === "M") {
+  if (effectiveScope === "M") {
     // M: two-phase
     if (hasLabel(lbls, "spec-merged")) {
       if (isPlanOnly) return "stop-after-plan-done";
@@ -129,7 +127,7 @@ export function deriveState(repo: string, issueNum: string, labels?: string[]): 
     return "needs-spec";
   }
 
-  if (scope === "L") {
+  if (effectiveScope === "L") {
     // L: spec only, human does code
     if (hasLabel(lbls, "spec-pending") || hasLabel(lbls, "spec-merged")) {
       return "stop-after-plan-done";


### PR DESCRIPTION
---  
## Why is this necessary?  
- 修復 deriveState 函數中的邏輯錯誤，避免在無 scope 標籤時出現不正確的行為。  
- 確保應用在特定情況下的穩定性，提升用戶體驗。  
- 減少潛在的錯誤和異常，增強代碼的可維護性。  

## How does it address?  
- 針對 state.ts 中的 deriveState 函數進行了修正，移除了死分支的邏輯。  
- 在無 scope 標籤的情況下，實現了正確的回退機制，確保返回 M 行為。  
- 進行了代碼審查，確保修復後的代碼符合最佳實踐並且易於理解。  