### PR TITLE
fix(routine-c): 修正解析 PR 內容以使用關閉關鍵字

### DIFF
--- a/bin/routine-c/sync-done.ts
+++ b/bin/routine-c/sync-done.ts
@@ -105,13 +105,20 @@ function getMergedTrackedPRs(repo: string, sinceIso: string): PR[] {
 
 function getLinkedIssueNumbers(repo: string, prNumber: number): number[] {
   try {
+    // closingIssuesReferences only works when PR targets the default branch.
+    // Parse the PR body directly for closing keywords as a reliable fallback.
     const output = execSync(
-      `gh pr view ${prNumber} --repo daodaoedu/${repo} \
-        --json closingIssuesReferences \
-        --jq '[.closingIssuesReferences[].number]'`,
+      `gh pr view ${prNumber} --repo daodaoedu/${repo} --json body --jq '.body'`,
       { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
     );
-    return JSON.parse(output.trim()) as number[];
+    const body = output.trim();
+    const CLOSING_RE = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
+    const nums: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = CLOSING_RE.exec(body)) !== null) {
+      nums.push(parseInt(m[1], 10));
+    }
+    return nums;
   } catch {
     return [];
   }

--- a/bin/routine-c/sync-done.ts
+++ b/bin/routine-c/sync-done.ts
@@ -112,13 +112,13 @@ function getLinkedIssueNumbers(repo: string, prNumber: number): number[] {
       { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
     );
     const body = output.trim();
-    const CLOSING_RE = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
-    const nums: number[] = [];
+    const CLOSING_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+    const nums = new Set<number>();
     let m: RegExpExecArray | null;
     while ((m = CLOSING_RE.exec(body)) !== null) {
-      nums.push(parseInt(m[1], 10));
+      nums.add(parseInt(m[1], 10));
     }
-    return nums;
+    return Array.from(nums);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Why is this necessary?

1. 目前的實作使用 `closingIssuesReferences` 來解析 PR 內容，可能導致關閉關鍵字無法正確識別。
2. 修正此問題可以提高 PR 關閉功能的準確性，確保相關問題能夠正確關閉。
3. 使用關閉關鍵字能使 PR 的管理更加直觀，增強團隊協作效率。

## How does it address?

1. 修改了 PR 解析邏輯，將其改為使用關閉關鍵字進行識別。
2. 確保在 PR 內容中出現的關閉關鍵字能夠被正確解析並執行關閉操作。
3. 測試了新的解析邏輯，確保其在不同情況下的穩定性和準確性。