### PR TITLE
feat(automation): 新增 AI review 品質週報

### DIFF
--- a/.github/workflows/review-evals.yml
+++ b/.github/workflows/review-evals.yml
@@ -1,0 +1,72 @@
+name: Pipeline — AI Review Weekly Evals
+
+on:
+  schedule:
+    - cron: '23 22 * * 0'  # 週日 22:23 UTC = 週一 06:23 台北
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Lookback window in days (default: 7)'
+        type: string
+        default: '7'
+      dry_run:
+        description: 'Dry run (no commit)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ai-review-weekly-evals
+  cancel-in-progress: false
+
+jobs:
+  evals:
+    name: Collect review acceptance stats
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.15.1'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run review-evals
+        env:
+          # PAT：要能讀所有 sub-repo 的 PR/comments
+          GH_TOKEN: ${{ secrets.GIT_HUB_ACCESS_TOKEN }}
+          EVAL_DAYS: ${{ inputs.days || '7' }}
+          EVAL_DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GIT_HUB_ACCESS_TOKEN is required for cross-repo review metrics"
+            exit 1
+          fi
+          args=(--days "$EVAL_DAYS")
+          if [ "$EVAL_DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+          pnpm tsx bin/pipeline/review-evals.ts "${args[@]}"
+
+      - name: Commit evals.md
+        if: inputs.dry_run != true
+        run: |
+          if git diff --quiet docs/automation/evals.md; then
+            echo "no changes"
+            exit 0
+          fi
+          git config user.name "daodao-pipeline"
+          git config user.email "noreply@daodaoedu.github.com"
+          git add docs/automation/evals.md
+          git commit -m "chore(automation): weekly review evals [skip ci]"
+          git push origin HEAD

--- a/bin/pipeline/__tests__/review-evals.test.ts
+++ b/bin/pipeline/__tests__/review-evals.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEvalsRow,
+  classifyFindings,
+  commitFilesFromPages,
+  commitsAfterReview,
+  fileWasTouched,
+  hasAuthorReply,
+  insertEvalsRow,
+  normalizeCommentPages,
+  parseDays,
+  parseReviewFindings,
+  selectLatestBotReview,
+} from "../review-evals.js";
+
+const REVIEW_BODY = `## Code Review
+
+### 問題
+
+| 嚴重度 | 檔案 | 問題 | 建議 |
+|--------|------|------|------|
+| 🔴 High | \`.github/scripts/retrieve-context.sh\` | Incomplete scope：漏掉同類呼叫點 | 補齊 |
+| 🟡 Medium | \`src/lib/sdk.ts:42\` | 效能疑慮 | 加 cache |
+| 🟢 Low | \`README.md\` | 風格 | 可忽略 |
+
+### 總結
+
+一句話。`;
+
+describe("parseReviewFindings", () => {
+  it("parses severity, file, and incomplete-scope flag from the table", () => {
+    const f = parseReviewFindings(REVIEW_BODY);
+    expect(f).toHaveLength(3);
+    expect(f[0]).toEqual({
+      severity: "High",
+      file: ".github/scripts/retrieve-context.sh",
+      incompleteScope: true,
+    });
+    expect(f[1]!.severity).toBe("Medium");
+    expect(f[2]!.incompleteScope).toBe(false);
+  });
+  it("returns empty for no-issue reviews", () => {
+    expect(parseReviewFindings("## Code Review\n\n✅ 沒有發現明顯問題")).toEqual([]);
+  });
+});
+
+describe("fileWasTouched", () => {
+  it("matches exact path, ./ prefix, :line suffix, and unique basename", () => {
+    expect(fileWasTouched("src/lib/sdk.ts:42", ["src/lib/sdk.ts"])).toBe(true);
+    expect(fileWasTouched("./src/a.ts", ["src/a.ts"])).toBe(true);
+    expect(fileWasTouched("sdk.ts", ["src/lib/sdk.ts"])).toBe(true);
+    expect(fileWasTouched("src/other.ts", ["src/lib/sdk.ts"])).toBe(false);
+    expect(fileWasTouched("", ["src/lib/sdk.ts"])).toBe(false);
+  });
+
+  it("does not treat a different path or ambiguous basename as fixed", () => {
+    expect(fileWasTouched("src/a/index.ts", ["src/b/index.ts"])).toBe(false);
+    expect(fileWasTouched("index.ts", ["src/a/index.ts", "src/b/index.ts"])).toBe(false);
+  });
+});
+
+describe("hasAuthorReply", () => {
+  const comments = [
+    { createdAt: "2026-08-21T10:01:00Z", login: "reviewer" },
+    { createdAt: "2026-08-21T10:02:00Z", login: "github-actions[bot]" },
+  ];
+
+  it("does not count third-party or bot comments as an author reply", () => {
+    expect(hasAuthorReply(comments, "2026-08-21T10:00:00Z", "author")).toBe(false);
+  });
+
+  it("counts only the PR author's later comment", () => {
+    expect(
+      hasAuthorReply(
+        [...comments, { createdAt: "2026-08-21T10:03:00Z", login: "author" }],
+        "2026-08-21T10:00:00Z",
+        "author"
+      )
+    ).toBe(true);
+  });
+});
+
+describe("selectLatestBotReview", () => {
+  const botReview = {
+    body: "## Code Review\n\n<!-- daodao-ai-code-review -->",
+    createdAt: "2026-08-21T10:00:00Z",
+    updatedAt: "2026-08-21T12:00:00Z",
+    login: "github-actions[bot]",
+  };
+
+  it("uses updatedAt as the cutoff for commits and author replies", () => {
+    const selected = selectLatestBotReview([botReview]);
+    expect(selected?.updatedAt).toBe("2026-08-21T12:00:00Z");
+
+    const commits = commitsAfterReview(
+      [
+        { oid: "before", date: "2026-08-21T11:00:00Z" },
+        { oid: "after", date: "2026-08-21T12:01:00Z" },
+      ],
+      selected!.updatedAt
+    );
+    expect(commits.map((commit) => commit.oid)).toEqual(["after"]);
+    expect(
+      hasAuthorReply(
+        [
+          { createdAt: "2026-08-21T11:00:00Z", login: "author" },
+          { createdAt: "2026-08-21T12:01:00Z", login: "author" },
+        ],
+        selected!.updatedAt,
+        "author"
+      )
+    ).toBe(true);
+    expect(
+      hasAuthorReply(
+        [{ createdAt: "2026-08-21T11:00:00Z", login: "author" }],
+        selected!.updatedAt,
+        "author"
+      )
+    ).toBe(false);
+  });
+
+  it("ignores a newer fake human review even when it copies the marker", () => {
+    const fakeHumanReview = {
+      ...botReview,
+      body: "## Code Review\n\n<!-- daodao-ai-code-review -->\n| High | fake |",
+      createdAt: "2026-08-21T13:00:00Z",
+      updatedAt: "2026-08-21T13:00:00Z",
+      login: "attacker",
+    };
+    expect(selectLatestBotReview([botReview, fakeHumanReview])).toEqual(botReview);
+  });
+
+  it("rejects bot comments without the dedicated marker", () => {
+    expect(
+      selectLatestBotReview([
+        { ...botReview, body: "## Code Review\n\n| High | unrelated |" },
+      ])
+    ).toBeUndefined();
+  });
+});
+
+describe("paginated GitHub responses", () => {
+  it("flattens issue comments while preserving created and updated timestamps", () => {
+    expect(
+      normalizeCommentPages([
+        [{
+          body: "first",
+          created_at: "2026-08-21T10:00:00Z",
+          updated_at: "2026-08-21T12:00:00Z",
+          user: { login: "github-actions[bot]" },
+        }],
+        [{
+          body: "second",
+          created_at: "2026-08-21T13:00:00Z",
+          updated_at: "2026-08-21T13:00:00Z",
+          user: { login: "author" },
+        }],
+      ])
+    ).toEqual([
+      {
+        body: "first",
+        createdAt: "2026-08-21T10:00:00Z",
+        updatedAt: "2026-08-21T12:00:00Z",
+        login: "github-actions[bot]",
+      },
+      {
+        body: "second",
+        createdAt: "2026-08-21T13:00:00Z",
+        updatedAt: "2026-08-21T13:00:00Z",
+        login: "author",
+      },
+    ]);
+  });
+
+  it("flattens commit file pages without relying on gh --jq", () => {
+    expect(
+      commitFilesFromPages([
+        { files: [{ filename: "src/a.ts" }] },
+        { files: [{ filename: "src/b.ts" }] },
+      ])
+    ).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+});
+
+describe("classifyFindings", () => {
+  const findings = parseReviewFindings(REVIEW_BODY);
+  it("fixed when touched, replied when author responded, else silent", () => {
+    expect(classifyFindings(findings, ["src/lib/sdk.ts"], false)).toEqual({
+      fixed: 1, replied: 0, silent: 2,
+    });
+    expect(classifyFindings(findings, [], true)).toEqual({
+      fixed: 0, replied: 3, silent: 0,
+    });
+    expect(classifyFindings(findings, [], false)).toEqual({
+      fixed: 0, replied: 0, silent: 3,
+    });
+  });
+});
+
+describe("buildEvalsRow", () => {
+  it("computes acceptance rate", () => {
+    const row = buildEvalsRow("2026-08-21T00:00:00Z", {
+      repo: "all", prsWithReview: 2, findings: 4, high: 1, incompleteScope: 1,
+      fixed: 3, replied: 1, silent: 0,
+    });
+    expect(row).toBe("| 2026-08-21 | 2 | 4 | 1 | 1 | 3 | 1 | 0 | 75% |");
+  });
+  it("0% when no findings", () => {
+    expect(
+      buildEvalsRow("2026-08-21T00:00:00Z", {
+        repo: "all", prsWithReview: 0, findings: 0, high: 0, incompleteScope: 0,
+        fixed: 0, replied: 0, silent: 0,
+      })
+    ).toContain("| 0% |");
+  });
+});
+
+describe("insertEvalsRow", () => {
+  it("inserts into the review-evals table rather than an earlier table", () => {
+    const content = `# Evals
+
+| Other | Table |
+|---|---|
+| old | value |
+
+## AI Review 接受率（weekly）<!-- review-evals -->
+
+| 週 | findings |
+|---|---|
+| 2026-08-20 | 1 |
+`;
+    const updated = insertEvalsRow(content, "| 2026-08-21 | 2 |");
+    expect(updated.indexOf("| old | value |")).toBeLessThan(
+      updated.indexOf("| 2026-08-21 | 2 |")
+    );
+    expect(updated.indexOf("| 2026-08-21 | 2 |")).toBeLessThan(
+      updated.indexOf("| 2026-08-20 | 1 |")
+    );
+  });
+});
+
+describe("parseDays", () => {
+  it("defaults to seven and accepts a bounded positive integer", () => {
+    expect(parseDays(["node", "script"])).toBe(7);
+    expect(parseDays(["node", "script", "--days", "30"])).toBe(30);
+  });
+
+  it.each(["0", "-1", "91", "abc", ""])("rejects invalid value %j", (value) => {
+    expect(() => parseDays(["node", "script", "--days", value])).toThrow(
+      "between 1 and 90"
+    );
+  });
+});

--- a/bin/pipeline/__tests__/review-evals.test.ts
+++ b/bin/pipeline/__tests__/review-evals.test.ts
@@ -3,7 +3,7 @@ import {
   buildEvalsRow,
   classifyFindings,
   commitFilesFromPages,
-  commitsAfterReview,
+  commitsAfterReviewedHead,
   fileWasTouched,
   hasAuthorReply,
   insertEvalsRow,
@@ -26,6 +26,11 @@ const REVIEW_BODY = `## Code Review
 ### 總結
 
 一句話。`;
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+const snapshotBody = (headSha: string, body = REVIEW_BODY) =>
+  `${body}\n\n<!-- daodao-ai-code-review -->\n<!-- daodao-ai-code-review-head:${headSha} -->`;
 
 describe("parseReviewFindings", () => {
   it("parses severity, file, and incomplete-scope flag from the table", () => {
@@ -82,24 +87,26 @@ describe("hasAuthorReply", () => {
 
 describe("selectLatestBotReview", () => {
   const botReview = {
-    body: "## Code Review\n\n<!-- daodao-ai-code-review -->",
+    body: snapshotBody(HEAD_A),
     createdAt: "2026-08-21T10:00:00Z",
     updatedAt: "2026-08-21T12:00:00Z",
     login: "github-actions[bot]",
   };
 
-  it("uses updatedAt as the cutoff for commits and author replies", () => {
-    const selected = selectLatestBotReview([botReview]);
+  it("uses the reviewed head position for commits and updatedAt for author replies", () => {
+    const selected = selectLatestBotReview([botReview], "2026-08-21T00:00:00Z");
     expect(selected?.updatedAt).toBe("2026-08-21T12:00:00Z");
+    expect(selected?.headSha).toBe(HEAD_A);
 
-    const commits = commitsAfterReview(
+    const commits = commitsAfterReviewedHead(
       [
-        { oid: "before", date: "2026-08-21T11:00:00Z" },
-        { oid: "after", date: "2026-08-21T12:01:00Z" },
+        { oid: "before", date: "2026-08-21T13:00:00Z" },
+        { oid: HEAD_A, date: "2026-08-21T10:00:00Z" },
+        { oid: "after", date: "2026-08-21T09:00:00Z" },
       ],
-      selected!.updatedAt
+      selected!.headSha
     );
-    expect(commits.map((commit) => commit.oid)).toEqual(["after"]);
+    expect(commits?.map((commit) => commit.oid)).toEqual(["after"]);
     expect(
       hasAuthorReply(
         [
@@ -122,20 +129,65 @@ describe("selectLatestBotReview", () => {
   it("ignores a newer fake human review even when it copies the marker", () => {
     const fakeHumanReview = {
       ...botReview,
-      body: "## Code Review\n\n<!-- daodao-ai-code-review -->\n| High | fake |",
+      body: snapshotBody(HEAD_B),
       createdAt: "2026-08-21T13:00:00Z",
       updatedAt: "2026-08-21T13:00:00Z",
       login: "attacker",
     };
-    expect(selectLatestBotReview([botReview, fakeHumanReview])).toEqual(botReview);
+    expect(
+      selectLatestBotReview([botReview, fakeHumanReview], "2026-08-21T00:00:00Z")
+    ).toEqual({ ...botReview, headSha: HEAD_A });
   });
 
-  it("rejects bot comments without the dedicated marker", () => {
+  it("selects by updatedAt rather than API array order", () => {
+    const newer = {
+      ...botReview,
+      body: snapshotBody(HEAD_B),
+      updatedAt: "2026-08-21T13:00:00Z",
+    };
+    expect(
+      selectLatestBotReview([newer, botReview], "2026-08-21T00:00:00Z")?.headSha
+    ).toBe(HEAD_B);
+  });
+
+  it("excludes snapshots updated before the lookback", () => {
+    expect(
+      selectLatestBotReview([botReview], "2026-08-21T12:30:00Z")
+    ).toBeUndefined();
+  });
+
+  it("keeps the latest finding snapshot when a newer snapshot is clean", () => {
+    const clean = {
+      ...botReview,
+      body: snapshotBody(HEAD_B, "## Code Review\n\n✅ 沒有發現明顯問題"),
+      updatedAt: "2026-08-21T13:00:00Z",
+    };
+    expect(
+      selectLatestBotReview([botReview, clean], "2026-08-21T00:00:00Z")?.headSha
+    ).toBe(HEAD_A);
+  });
+
+  it("rejects bot comments without both dedicated markers", () => {
     expect(
       selectLatestBotReview([
         { ...botReview, body: "## Code Review\n\n| High | unrelated |" },
-      ])
+      ], "2026-08-21T00:00:00Z")
     ).toBeUndefined();
+    expect(
+      selectLatestBotReview([
+        { ...botReview, body: `${REVIEW_BODY}\n<!-- daodao-ai-code-review -->` },
+      ], "2026-08-21T00:00:00Z")
+    ).toBeUndefined();
+    expect(
+      selectLatestBotReview([
+        { ...botReview, body: snapshotBody("A".repeat(40)) },
+      ], "2026-08-21T00:00:00Z")
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the reviewed head is absent from PR commits", () => {
+    expect(commitsAfterReviewedHead([{ oid: "before" }, { oid: "after" }], HEAD_A))
+      .toBeUndefined();
   });
 });
 
@@ -236,6 +288,22 @@ describe("insertEvalsRow", () => {
     expect(updated.indexOf("| 2026-08-21 | 2 |")).toBeLessThan(
       updated.indexOf("| 2026-08-20 | 1 |")
     );
+  });
+
+  it("replaces the same UTC date row instead of duplicating it", () => {
+    const content = `# Evals
+
+## AI Review 接受率（weekly）<!-- review-evals -->
+
+| 週 | findings |
+|---|---|
+| 2026-08-21 | old |
+| 2026-08-20 | 1 |
+`;
+    const updated = insertEvalsRow(content, "| 2026-08-21 | new |");
+    expect(updated.match(/\| 2026-08-21 \|/g)).toHaveLength(1);
+    expect(updated).toContain("| 2026-08-21 | new |");
+    expect(updated).not.toContain("| 2026-08-21 | old |");
   });
 });
 

--- a/bin/pipeline/__tests__/review-evals.test.ts
+++ b/bin/pipeline/__tests__/review-evals.test.ts
@@ -44,6 +44,18 @@ describe("parseReviewFindings", () => {
     expect(f[1]!.severity).toBe("Medium");
     expect(f[2]!.incompleteScope).toBe(false);
   });
+
+  it("parses a plain file cell without mistaking issue code for the path", () => {
+    const findings = parseReviewFindings(
+      "| 🟡 Medium | src/lib/sdk.ts:42 | `request()` 沒有 timeout | 加上 timeout |"
+    );
+    expect(findings).toEqual([{
+      severity: "Medium",
+      file: "src/lib/sdk.ts:42",
+      incompleteScope: false,
+    }]);
+  });
+
   it("returns empty for no-issue reviews", () => {
     expect(parseReviewFindings("## Code Review\n\n✅ 沒有發現明顯問題")).toEqual([]);
   });
@@ -61,6 +73,11 @@ describe("fileWasTouched", () => {
   it("does not treat a different path or ambiguous basename as fixed", () => {
     expect(fileWasTouched("src/a/index.ts", ["src/b/index.ts"])).toBe(false);
     expect(fileWasTouched("index.ts", ["src/a/index.ts", "src/b/index.ts"])).toBe(false);
+  });
+
+  it("deduplicates repeated touches to one path without merging distinct paths", () => {
+    expect(fileWasTouched("sdk.ts", ["src/lib/sdk.ts", "src/lib/sdk.ts"])).toBe(true);
+    expect(fileWasTouched("sdk.ts", ["src/lib/sdk.ts", "src/other/sdk.ts"])).toBe(false);
   });
 });
 

--- a/bin/pipeline/review-evals.ts
+++ b/bin/pipeline/review-evals.ts
@@ -26,6 +26,7 @@ const DAYS = parseDays(process.argv);
 const REPOS = [CENTRAL_REPO, ...SUB_REPOS];
 const BOT_LOGINS = new Set(["github-actions", "github-actions[bot]"]);
 const REVIEW_MARKER = "<!-- daodao-ai-code-review -->";
+const REVIEW_HEAD_RE = /<!-- daodao-ai-code-review-head:([0-9a-f]{40}) -->/;
 const EVALS_PATH = join(process.cwd(), "docs", "automation", "evals.md");
 const MARKER = "<!-- review-evals -->";
 
@@ -126,6 +127,10 @@ export interface ReviewComment {
   login: string;
 }
 
+export interface ReviewSnapshot extends ReviewComment {
+  headSha: string;
+}
+
 interface ApiIssueComment {
   body: string;
   created_at: string;
@@ -148,23 +153,40 @@ export function commitFilesFromPages(
   return pages.flatMap((page) => page.files ?? []).map((file) => file.filename);
 }
 
-/** 只接受本專案 AI reviewer bot 寫入、且帶穩定 marker 的 review。 */
-export function selectLatestBotReview(comments: ReviewComment[]): ReviewComment | undefined {
+/**
+ * 只接受 lookback 內、本專案 bot 寫入的 per-head finding snapshot。
+ * GitHub API 陣列順序不是 contract，所以明確依 updatedAt 取最新。
+ */
+export function selectLatestBotReview(
+  comments: ReviewComment[],
+  sinceIso: string
+): ReviewSnapshot | undefined {
   return comments
-    .filter(
-      (comment) =>
-        BOT_LOGINS.has(comment.login) &&
-        comment.body.startsWith("## Code Review") &&
-        comment.body.includes(REVIEW_MARKER)
-    )
+    .flatMap((comment): ReviewSnapshot[] => {
+      const headMatch = REVIEW_HEAD_RE.exec(comment.body);
+      if (
+        !BOT_LOGINS.has(comment.login) ||
+        !comment.body.startsWith("## Code Review") ||
+        !comment.body.includes(REVIEW_MARKER) ||
+        !headMatch ||
+        comment.updatedAt < sinceIso ||
+        parseReviewFindings(comment.body).length === 0
+      ) {
+        return [];
+      }
+      return [{ ...comment, headSha: headMatch[1]! }];
+    })
+    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt))
     .pop();
 }
 
-export function commitsAfterReview<T extends { date: string }>(
+export function commitsAfterReviewedHead<T extends { oid: string }>(
   commits: T[],
-  reviewUpdatedAt: string
-): T[] {
-  return commits.filter((commit) => commit.date > reviewUpdatedAt);
+  headSha: string
+): T[] | undefined {
+  const reviewedHeadIndex = commits.findIndex((commit) => commit.oid === headSha);
+  if (reviewedHeadIndex === -1) return undefined;
+  return commits.slice(reviewedHeadIndex + 1);
 }
 
 interface RepoStats {
@@ -201,26 +223,32 @@ function collectRepo(repo: string, sinceIso: string): RepoStats {
     const comments = normalizeCommentPages(
       JSON.parse(commentsJson) as ApiIssueComment[][]
     );
-    const review = selectLatestBotReview(comments);
+    const review = selectLatestBotReview(comments, sinceIso);
     if (!review) continue;
 
     const findings = parseReviewFindings(review.body);
-    if (findings.length === 0) continue;
+
+    // reviewed head 之後動過的檔案；不依賴 commit timestamp。
+    const commitsJson = gh([
+      "pr", "view", String(pr.number),
+      "--repo", `${OWNER}/${repo}`,
+      "--json", "commits",
+      "--jq", "[.commits[] | {oid}]",
+    ]);
+    const commits = JSON.parse(commitsJson) as Array<{ oid: string }>;
+    const commitsAfterReview = commitsAfterReviewedHead(commits, review.headSha);
+    if (!commitsAfterReview) {
+      log(`${repo}#${pr.number}: review head ${review.headSha} not found; skipping`);
+      continue;
+    }
+
     stats.prsWithReview++;
     stats.findings += findings.length;
     stats.high += findings.filter((f) => f.severity === "High").length;
     stats.incompleteScope += findings.filter((f) => f.incompleteScope).length;
 
-    // review 之後動過的檔案
-    const commitsJson = gh([
-      "pr", "view", String(pr.number),
-      "--repo", `${OWNER}/${repo}`,
-      "--json", "commits",
-      "--jq", "[.commits[] | {oid, date: .committedDate}]",
-    ]);
-    const commits = JSON.parse(commitsJson) as Array<{ oid: string; date: string }>;
     const touched: string[] = [];
-    for (const c of commitsAfterReview(commits, review.updatedAt)) {
+    for (const c of commitsAfterReview) {
       const files = gh([
         "api", "--paginate", "--slurp",
         `repos/${OWNER}/${repo}/commits/${c.oid}`,
@@ -265,6 +293,19 @@ export function insertEvalsRow(content: string, row: string): string {
   );
   if (separatorIndex === -1) {
     throw new Error("review-evals marker exists without its table separator");
+  }
+
+  const rowDate = /^\|\s*(\d{4}-\d{2}-\d{2})\s*\|/.exec(row)?.[1];
+  if (!rowDate) {
+    throw new Error("review-evals row must start with an ISO UTC date");
+  }
+  for (let index = separatorIndex + 1; index < lines.length; index++) {
+    if (!lines[index]!.startsWith("|")) break;
+    const existingDate = /^\|\s*(\d{4}-\d{2}-\d{2})\s*\|/.exec(lines[index]!)?.[1];
+    if (existingDate === rowDate) {
+      lines[index] = row;
+      return lines.join("\n");
+    }
   }
   lines.splice(separatorIndex + 1, 0, row);
   return lines.join("\n");

--- a/bin/pipeline/review-evals.ts
+++ b/bin/pipeline/review-evals.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * review-evals: AI code review 接受率週報
+ *
+ * Usage:
+ *   pnpm tsx bin/pipeline/review-evals.ts [--days 7] [--dry-run]
+ *
+ * Env:
+ *   GH_TOKEN / GITHUB_TOKEN — 需可讀所有 sub-repo（cross-repo 用 PAT）
+ *
+ * 對每個 repo 掃近 N 天有「## Code Review」comment 的 PR，把每條發現分類：
+ *   fixed   — review 之後的 commit 動過被點名的檔案（視為被接受）
+ *   replied — 沒改檔案，但作者在 review 之後有留言（視為被討論/反駁）
+ *   silent  — 兩者皆無（被忽略）
+ * 誤報率比攔截率重要：silent+replied 偏高就該回頭修 prompt 或濾噪。
+ * 結果 append 到 docs/automation/evals.md 的 review-evals 區塊。
+ */
+import { execFileSync } from "child_process";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { CENTRAL_REPO, OWNER, SUB_REPOS } from "./types.js";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const DAYS = parseDays(process.argv);
+
+const REPOS = [CENTRAL_REPO, ...SUB_REPOS];
+const BOT_LOGINS = new Set(["github-actions", "github-actions[bot]"]);
+const REVIEW_MARKER = "<!-- daodao-ai-code-review -->";
+const EVALS_PATH = join(process.cwd(), "docs", "automation", "evals.md");
+const MARKER = "<!-- review-evals -->";
+
+function log(msg: string): void {
+  process.stdout.write(`[review-evals] ${msg}\n`);
+}
+
+function gh(args: string[]): string {
+  return execFileSync("gh", args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export function parseDays(args: string[]): number {
+  const index = args.indexOf("--days");
+  const raw = index === -1 ? "7" : args[index + 1];
+  if (!raw || !/^\d+$/.test(raw)) {
+    throw new Error("--days must be an integer between 1 and 90");
+  }
+  const days = Number(raw);
+  if (days < 1 || days > 90) {
+    throw new Error("--days must be an integer between 1 and 90");
+  }
+  return days;
+}
+
+export interface Finding {
+  severity: "High" | "Medium" | "Low";
+  file: string;
+  incompleteScope: boolean;
+}
+
+/** 從「## Code Review」comment 的問題表格解析發現清單。 */
+export function parseReviewFindings(body: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const line of body.split("\n")) {
+    const m = /^\|\s*(?:🔴|🟡|🟢)?\s*(High|Medium|Low)\s*\|(.+)$/.exec(line.trim());
+    if (!m) continue;
+    const rest = m[2]!;
+    const fileMatch = /`([^`]+)`/.exec(rest);
+    findings.push({
+      severity: m[1] as Finding["severity"],
+      file: fileMatch?.[1] ?? "",
+      incompleteScope: /incomplete scope/i.test(rest),
+    });
+  }
+  return findings;
+}
+
+/** 完整 path 只做 exact；只有模型只寫 basename 且唯一命中時才視為 touched。 */
+export function fileWasTouched(flagged: string, touched: string[]): boolean {
+  if (!flagged) return false;
+  const clean = flagged.replace(/^\.\//, "").split(":")[0]!; // 去掉可能的 :line
+  if (clean.includes("/")) return touched.includes(clean);
+  const base = clean.split("/").pop()!;
+  const matches = touched.filter((t) => t === base || t.endsWith(`/${base}`));
+  return matches.length === 1;
+}
+
+interface Outcome {
+  fixed: number;
+  replied: number;
+  silent: number;
+}
+
+export function classifyFindings(
+  findings: Finding[],
+  touchedAfterReview: string[],
+  authorRepliedAfterReview: boolean
+): Outcome {
+  const out: Outcome = { fixed: 0, replied: 0, silent: 0 };
+  for (const f of findings) {
+    if (fileWasTouched(f.file, touchedAfterReview)) out.fixed++;
+    else if (authorRepliedAfterReview) out.replied++;
+    else out.silent++;
+  }
+  return out;
+}
+
+export function hasAuthorReply(
+  comments: Array<{ createdAt: string; login: string }>,
+  reviewCreatedAt: string,
+  authorLogin: string
+): boolean {
+  return comments.some(
+    (comment) =>
+      comment.createdAt > reviewCreatedAt &&
+      comment.login === authorLogin &&
+      !BOT_LOGINS.has(comment.login)
+  );
+}
+
+export interface ReviewComment {
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  login: string;
+}
+
+interface ApiIssueComment {
+  body: string;
+  created_at: string;
+  updated_at: string;
+  user: { login: string };
+}
+
+export function normalizeCommentPages(pages: ApiIssueComment[][]): ReviewComment[] {
+  return pages.flat().map((comment) => ({
+    body: comment.body,
+    createdAt: comment.created_at,
+    updatedAt: comment.updated_at,
+    login: comment.user.login,
+  }));
+}
+
+export function commitFilesFromPages(
+  pages: Array<{ files?: Array<{ filename: string }> }>
+): string[] {
+  return pages.flatMap((page) => page.files ?? []).map((file) => file.filename);
+}
+
+/** 只接受本專案 AI reviewer bot 寫入、且帶穩定 marker 的 review。 */
+export function selectLatestBotReview(comments: ReviewComment[]): ReviewComment | undefined {
+  return comments
+    .filter(
+      (comment) =>
+        BOT_LOGINS.has(comment.login) &&
+        comment.body.startsWith("## Code Review") &&
+        comment.body.includes(REVIEW_MARKER)
+    )
+    .pop();
+}
+
+export function commitsAfterReview<T extends { date: string }>(
+  commits: T[],
+  reviewUpdatedAt: string
+): T[] {
+  return commits.filter((commit) => commit.date > reviewUpdatedAt);
+}
+
+interface RepoStats {
+  repo: string;
+  prsWithReview: number;
+  findings: number;
+  high: number;
+  incompleteScope: number;
+  fixed: number;
+  replied: number;
+  silent: number;
+}
+
+function collectRepo(repo: string, sinceIso: string): RepoStats {
+  const stats: RepoStats = {
+    repo, prsWithReview: 0, findings: 0, high: 0, incompleteScope: 0,
+    fixed: 0, replied: 0, silent: 0,
+  };
+  const prsJson = gh([
+    "pr", "list",
+    "--repo", `${OWNER}/${repo}`,
+    "--state", "all",
+    "--limit", "100",
+    "--search", `updated:>=${sinceIso.slice(0, 10)}`,
+    "--json", "number,author",
+  ]);
+  const prs = JSON.parse(prsJson) as Array<{ number: number; author: { login: string } }>;
+
+  for (const pr of prs) {
+    const commentsJson = gh([
+      "api", "--paginate", "--slurp",
+      `repos/${OWNER}/${repo}/issues/${pr.number}/comments`,
+    ]);
+    const comments = normalizeCommentPages(
+      JSON.parse(commentsJson) as ApiIssueComment[][]
+    );
+    const review = selectLatestBotReview(comments);
+    if (!review) continue;
+
+    const findings = parseReviewFindings(review.body);
+    if (findings.length === 0) continue;
+    stats.prsWithReview++;
+    stats.findings += findings.length;
+    stats.high += findings.filter((f) => f.severity === "High").length;
+    stats.incompleteScope += findings.filter((f) => f.incompleteScope).length;
+
+    // review 之後動過的檔案
+    const commitsJson = gh([
+      "pr", "view", String(pr.number),
+      "--repo", `${OWNER}/${repo}`,
+      "--json", "commits",
+      "--jq", "[.commits[] | {oid, date: .committedDate}]",
+    ]);
+    const commits = JSON.parse(commitsJson) as Array<{ oid: string; date: string }>;
+    const touched: string[] = [];
+    for (const c of commitsAfterReview(commits, review.updatedAt)) {
+      const files = gh([
+        "api", "--paginate", "--slurp",
+        `repos/${OWNER}/${repo}/commits/${c.oid}`,
+      ]);
+      touched.push(...commitFilesFromPages(
+        JSON.parse(files) as Array<{ files?: Array<{ filename: string }> }>
+      ));
+    }
+
+    const authorReplied = hasAuthorReply(comments, review.updatedAt, pr.author.login);
+
+    const outcome = classifyFindings(findings, touched, authorReplied);
+    stats.fixed += outcome.fixed;
+    stats.replied += outcome.replied;
+    stats.silent += outcome.silent;
+  }
+  return stats;
+}
+
+export function buildEvalsRow(dateIso: string, totals: RepoStats): string {
+  const rate = totals.findings > 0 ? Math.round((totals.fixed / totals.findings) * 100) : 0;
+  return `| ${dateIso.slice(0, 10)} | ${totals.prsWithReview} | ${totals.findings} | ${totals.high} | ${totals.incompleteScope} | ${totals.fixed} | ${totals.replied} | ${totals.silent} | ${rate}% |`;
+}
+
+const TABLE_HEADER = `## AI Review 接受率（weekly）${MARKER}
+
+> fixed = review 後 commit 動過被點名檔案；replied = 未改但作者有回；silent = 被忽略。
+> silent+replied 偏高 → 誤報太多，回頭修 prompt 或濾噪（狼來了兩次就沒人看）。
+
+| 週 | 有 review 的 PR | 發現 | 🔴 | Incomplete scope | fixed | replied | silent | 接受率 |
+|---|---|---|---|---|---|---|---|---|`;
+
+export function insertEvalsRow(content: string, row: string): string {
+  if (!content.includes(MARKER)) {
+    return `${content.trimEnd()}\n\n${TABLE_HEADER}\n${row}\n`;
+  }
+
+  const lines = content.split("\n");
+  const markerIndex = lines.findIndex((line) => line.includes(MARKER));
+  const separatorIndex = lines.findIndex(
+    (line, index) => index > markerIndex && line.startsWith("|---")
+  );
+  if (separatorIndex === -1) {
+    throw new Error("review-evals marker exists without its table separator");
+  }
+  lines.splice(separatorIndex + 1, 0, row);
+  return lines.join("\n");
+}
+
+function appendToEvals(row: string): void {
+  const content = existsSync(EVALS_PATH)
+    ? readFileSync(EVALS_PATH, "utf-8")
+    : "# Pipeline Weekly Evals\n";
+  writeFileSync(EVALS_PATH, insertEvalsRow(content, row), "utf-8");
+}
+
+function main(): void {
+  const sinceIso = new Date(Date.now() - DAYS * 24 * 3600 * 1000).toISOString();
+  const totals: RepoStats = {
+    repo: "all", prsWithReview: 0, findings: 0, high: 0, incompleteScope: 0,
+    fixed: 0, replied: 0, silent: 0,
+  };
+
+  for (const repo of REPOS) {
+    const s = collectRepo(repo, sinceIso);
+    if (s.prsWithReview > 0) {
+      log(`${repo}: ${s.prsWithReview} PR, ${s.findings} findings (fixed ${s.fixed} / replied ${s.replied} / silent ${s.silent})`);
+    }
+    totals.prsWithReview += s.prsWithReview;
+    totals.findings += s.findings;
+    totals.high += s.high;
+    totals.incompleteScope += s.incompleteScope;
+    totals.fixed += s.fixed;
+    totals.replied += s.replied;
+    totals.silent += s.silent;
+  }
+
+  const row = buildEvalsRow(new Date().toISOString(), totals);
+  log(`weekly row: ${row}`);
+  if (DRY_RUN) {
+    log("[dry-run] not writing evals.md");
+    return;
+  }
+  appendToEvals(row);
+  log(`written → ${EVALS_PATH}`);
+}
+
+const isDirectRun = process.argv[1]?.endsWith("review-evals.ts") ?? false;
+if (isDirectRun) main();

--- a/bin/pipeline/review-evals.ts
+++ b/bin/pipeline/review-evals.ts
@@ -67,10 +67,11 @@ export function parseReviewFindings(body: string): Finding[] {
     const m = /^\|\s*(?:🔴|🟡|🟢)?\s*(High|Medium|Low)\s*\|(.+)$/.exec(line.trim());
     if (!m) continue;
     const rest = m[2]!;
-    const fileMatch = /`([^`]+)`/.exec(rest);
+    const fileCell = rest.split("|", 1)[0]!.trim();
+    const quotedFile = /^`([^`]+)`$/.exec(fileCell);
     findings.push({
       severity: m[1] as Finding["severity"],
-      file: fileMatch?.[1] ?? "",
+      file: quotedFile?.[1] ?? fileCell,
       incompleteScope: /incomplete scope/i.test(rest),
     });
   }
@@ -83,8 +84,8 @@ export function fileWasTouched(flagged: string, touched: string[]): boolean {
   const clean = flagged.replace(/^\.\//, "").split(":")[0]!; // 去掉可能的 :line
   if (clean.includes("/")) return touched.includes(clean);
   const base = clean.split("/").pop()!;
-  const matches = touched.filter((t) => t === base || t.endsWith(`/${base}`));
-  return matches.length === 1;
+  const matches = new Set(touched.filter((t) => t === base || t.endsWith(`/${base}`)));
+  return matches.size === 1;
 }
 
 interface Outcome {

--- a/docs/automation/evals.md
+++ b/docs/automation/evals.md
@@ -1,10 +1,11 @@
 # Pipeline Weekly Evals
 
-> **此檔案將由 weekly cron 自動產生（v2 範圍）。**
->
-> 自動更新排程：`pnpm tsx bin/evals-snapshot.ts`（每週執行，commit 含 `[skip ci]`）。
-
-<!-- AUTO-GENERATED BELOW — DO NOT EDIT MANUALLY -->
+> AI review 接受率區塊由
+> [review-evals.yml](../../.github/workflows/review-evals.yml) 每週執行
+> `pnpm tsx bin/pipeline/review-evals.ts` 更新，commit 含 `[skip ci]`。
+> Cross-repo fine-grained PAT 只需在目標 repos 開啟 `Contents: read`、
+> `Issues: read` 與 `Pull requests: read`；workflow 的 `GITHUB_TOKEN`
+> 僅用於寫回本 repo 的週報。
 
 ## 指標說明
 
@@ -16,4 +17,16 @@
 | 人介次數 | per-issue intervention count（定義見 [troubleshooting.md#intervention-definition](troubleshooting.md#intervention-definition)） |
 | Council dissent rate | reviewer-agent 與 writer-agent 分歧率（5%~30% 為健康區間） |
 
-_（尚無資料，等待 bin/evals-snapshot.ts 初次執行）_
+_（既有 pipeline 指標尚無資料；AI review 接受率會由 weekly workflow 另加表格。）_
+
+## AI review 接受率的判定邊界
+
+- 只統計 `github-actions[bot]` 寫入、且帶有
+  `<!-- daodao-ai-code-review -->` marker 的 PR issue comment。
+- Reviewer 會更新同一則 comment，所以 commit 與回覆的比較基準是
+  comment 的 `updated_at`，不是第一次建立時的 `created_at`。
+- `replied` 只計 PR author 在 review 後的 issue comment；inline review thread
+  與第三方留言不計入。
+- `fixed` 是 proxy：若 GitHub 的 commit `committedDate` 晚於 review，且該
+  commit 碰過被點名的檔案，就視為已修復。這不能證明具體問題真的被修復，
+  也可能漏掉「本機早已 commit、review 後才 push」的情況。

--- a/docs/automation/evals.md
+++ b/docs/automation/evals.md
@@ -37,6 +37,13 @@ _（既有 pipeline 指標尚無資料；AI review 接受率會由 weekly workfl
   就視為已修復。這不依賴 `committedDate`，但仍不能證明具體問題真的被修復。
   snapshot head 不在 PR commits 中時，該 PR 會警告並跳過，避免產生不準數據。
 
+### Rollout dependency
+
+必須先合併並部署 producer 的 per-head snapshot 合約，再啟用這個
+consumer；root 與各 sub-repo 的 `code-review.yml` 都要先能產生上述
+generic + head markers。若 consumer 先上線，舊 producer 的 comments 會全被拒絕，
+weekly row 將誤寫為零；這種零值不得解讀為「沒有 findings」。
+
 ## 待辦：免費 reviewer 模型同場評測
 
 目前的本機 reviewer 預設只代表「已測試可用」，尚未經足以證明最佳的

--- a/docs/automation/evals.md
+++ b/docs/automation/evals.md
@@ -23,10 +23,30 @@ _（既有 pipeline 指標尚無資料；AI review 接受率會由 weekly workfl
 
 - 只統計 `github-actions[bot]` 寫入、且帶有
   `<!-- daodao-ai-code-review -->` marker 的 PR issue comment。
-- Reviewer 會更新同一則 comment，所以 commit 與回覆的比較基準是
-  comment 的 `updated_at`，不是第一次建立時的 `created_at`。
+- Reviewer producer 必須為每個 PR head 建立不可變的 finding snapshot，
+  comment 同時帶 `<!-- daodao-ai-code-review -->` 與
+  `<!-- daodao-ai-code-review-head:<40-char-lowercase-sha> -->`。新 head 必須
+  POST 新 comment；只有同 head 重跑可 PATCH 該 snapshot。
+- Consumer 只在 lookback 內的 bot snapshots 中，依 `updated_at` 取最新且
+  含 findings 的一則。後來的 clean snapshot 不會把前一個 finding
+  snapshot 的回饋窗口抹掉。
 - `replied` 只計 PR author 在 review 後的 issue comment；inline review thread
   與第三方留言不計入。
-- `fixed` 是 proxy：若 GitHub 的 commit `committedDate` 晚於 review，且該
-  commit 碰過被點名的檔案，就視為已修復。這不能證明具體問題真的被修復，
-  也可能漏掉「本機早已 commit、review 後才 push」的情況。
+- `fixed` 是 proxy：consumer 在 PR commits 陣列找到 snapshot head，並把
+  它之後的 commits 當作候選修正；若其中有 commit 碰過被點名的檔案，
+  就視為已修復。這不依賴 `committedDate`，但仍不能證明具體問題真的被修復。
+  snapshot head 不在 PR commits 中時，該 PR 會警告並跳過，避免產生不準數據。
+
+## 待辦：免費 reviewer 模型同場評測
+
+目前的本機 reviewer 預設只代表「已測試可用」，尚未經足以證明最佳的
+重複同場評測：OMP 使用 `openrouter/poolside/laguna-s-2.1:free`，OpenCode
+使用 `opencode/hy3-free`；Codex CLI 的目前預設模型作為品質基準，不列入
+免費模型排名。
+
+- [ ] 評測開始時保存 OpenRouter 與 OpenCode Zen 的即時免費模型清單，排除已下架、付費或浮動 alias。
+- [ ] 所有候選共用同一份 committed diff 與 Context Pack；每個 fixture 先 warm-up 一次，再正式執行至少五次。
+- [ ] 覆蓋 seeded finding、decoy、clean 與截斷邊界案例，並以真實 PR patch 補充驗證。
+- [ ] 記錄 finding recall、precision、clean pass、schema 解析成功率、timeout／錯誤率、p50／p95 延遲與多次輸出穩定性。
+- [ ] 主模型硬門檻為 5/5 可解析且不 timeout；clean fixture 不得產生 High／Medium 誤報，也不得捏造 diff／Context Pack 外的事實。
+- [ ] 將完整結果與選型理由寫回本文件後，才調整 `code-review` skill 的 OMP／OpenCode 預設模型。


### PR DESCRIPTION
## Summary
- add a scheduled/manual AI review eval workflow that scans review snapshots across daodao repos
- compute weekly fixed/replied/silent outcomes from bot review findings using exact per-head markers
- document rollout dependency, PAT scope, and current free-model evaluation TODOs

## Verification
- `pnpm exec vitest run --dir bin/pipeline review-evals` (28/28)
- targeted TypeScript check for `bin/pipeline/review-evals.ts`
- `git diff --check`

## Rollout dependency
Depends on #156. Merge #156 first so the code-review producer writes `<!-- daodao-ai-code-review -->` and exact head markers. If this runs before that producer is deployed, the weekly report can legitimately find zero marked snapshots.
