### PR TITLE
feat(ci): 新增可信 root branch flow guard

### DIFF
--- a/.github/scripts/check-branch-guard.sh
+++ b/.github/scripts/check-branch-guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Validate the root monorepo pull-request branch flow.
+set -euo pipefail
+
+HEAD="${HEAD:-${1:-}}"
+BASE="${BASE:-${2:-}}"
+CHANGED="${CHANGED:-${3:-0}}"
+
+BRANCH_RE='^(feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate)/.+'
+
+if [[ ! "$HEAD" =~ $BRANCH_RE ]]; then
+  echo "::error::分支名 '$HEAD' 不符慣例（type/description，type ∈ feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate）"
+  exit 1
+fi
+
+if [[ "$BASE" != "main" ]]; then
+  echo "::error::PR base 是 '$BASE'，monorepo 的 PR 應以 main 為 base"
+  exit 1
+fi
+
+if (( CHANGED > 60 )); then
+  echo "::warning::此 PR 變更 $CHANGED 個檔案（>60）——請確認沒有帶入非本題檔案或 base 選錯"
+fi
+
+echo "✅ branch guard passed: $HEAD → $BASE ($CHANGED files)"

--- a/.github/scripts/test-branch-guard.sh
+++ b/.github/scripts/test-branch-guard.sh
@@ -43,15 +43,39 @@ output="$(HEAD="feat/large-pr" BASE="main" CHANGED=61 "$CHECK" 2>&1)" || fail "6
 [[ "$output" == *"branch guard passed"* ]] || fail "61 files 缺少通過訊息：$output"
 echo "✅ 61 files warning/pass"
 
+job_section() {
+  local job="$1"
+  awk -v header="  $job:" '
+    $0 == header { inside = 1 }
+    inside && $0 != header && $0 ~ /^  [[:alnum:]_-]+:$/ { exit }
+    inside { print }
+  ' "$WORKFLOW"
+}
+
+guard_job="$(job_section guard)"
+regression_job="$(job_section regression)"
+
 base_load_pattern="git show \"\$BASE_SHA:.github/scripts/check-branch-guard.sh\" > \"\$TRUSTED_CHECK\""
 trusted_run_pattern="\"\$RUNNER_TEMP/check-branch-guard.sh\""
-grep -Fq "$base_load_pattern" "$WORKFLOW" \
+grep -Fq "$base_load_pattern" <<< "$guard_job" \
   || fail "workflow 未從 base SHA 載入可信腳本"
-grep -Fq "$trusted_run_pattern" "$WORKFLOW" \
+grep -Fq "$trusted_run_pattern" <<< "$guard_job" \
   || fail "workflow 未執行 runner 暫存目錄內的可信副本"
-if grep -Eq '^[[:space:]]+\.github/scripts/check-branch-guard\.sh([[:space:]]|$)' "$WORKFLOW"; then
-  fail "workflow 不得直接執行 PR checkout 內的腳本"
+if grep -Fq '.github/scripts/test-branch-guard.sh' <<< "$guard_job"; then
+  fail "production guard job 不得執行 PR checkout 內的測試"
 fi
 echo "✅ trusted base script boundary"
+
+[[ -n "$regression_job" ]] || fail "workflow 缺少 regression job"
+grep -Fq 'permissions: {}' <<< "$regression_job" \
+  || fail "regression job 必須使用 permissions: {}"
+grep -Fq 'persist-credentials: false' <<< "$regression_job" \
+  || fail "regression checkout 不得保留 credentials"
+grep -Fq 'run: .github/scripts/test-branch-guard.sh' <<< "$regression_job" \
+  || fail "regression job 未執行 PR 版本測試"
+if grep -Eq '(secrets\.|GITHUB_TOKEN|permissions:[[:space:]]*$)' <<< "$regression_job"; then
+  fail "regression job 不得取得 secrets、token 或額外 permissions"
+fi
+echo "✅ tokenless regression job contract"
 
 echo "✅ branch guard regression tests passed"

--- a/.github/scripts/test-branch-guard.sh
+++ b/.github/scripts/test-branch-guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression tests for check-branch-guard.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check-branch-guard.sh"
+WORKFLOW="$SCRIPT_DIR/../workflows/branch-guard.yml"
+
+fail() {
+  echo "❌ $1"
+  exit 1
+}
+
+expect_pass() {
+  local name="$1" head="$2" base="$3" changed="$4"
+  local output
+  if ! output="$(HEAD="$head" BASE="$base" CHANGED="$changed" "$CHECK" 2>&1)"; then
+    fail "$name 應通過，實際輸出：$output"
+  fi
+  [[ "$output" == *"branch guard passed"* ]] || fail "$name 缺少通過訊息：$output"
+  printf '✅ %s\n' "$name"
+}
+
+expect_fail() {
+  local name="$1" head="$2" base="$3" changed="$4" expected="$5"
+  local output
+  if output="$(HEAD="$head" BASE="$base" CHANGED="$changed" "$CHECK" 2>&1)"; then
+    fail "$name 應失敗，卻通過：$output"
+  fi
+  [[ "$output" == *"$expected"* ]] || fail "$name 錯誤訊息不符：$output"
+  printf '✅ %s\n' "$name"
+}
+
+expect_pass "feat/main" "feat/root-branch-guard" "main" 3
+expect_fail "invalid branch" "feature/root-branch-guard" "main" 3 "分支名"
+expect_fail "dev base" "feat/root-branch-guard" "dev" 3 "應以 main 為 base"
+expect_pass "dependabot" "dependabot/npm_and_yarn/actions-checkout-4" "main" 1
+expect_pass "ci prefix" "ci/harden-branch-guard" "main" 2
+expect_pass "build prefix" "build/update-toolchain" "main" 2
+
+output="$(HEAD="feat/large-pr" BASE="main" CHANGED=61 "$CHECK" 2>&1)" || fail "61 files 應警告但通過：$output"
+[[ "$output" == *"::warning::"* ]] || fail "61 files 缺少 warning：$output"
+[[ "$output" == *"branch guard passed"* ]] || fail "61 files 缺少通過訊息：$output"
+echo "✅ 61 files warning/pass"
+
+base_load_pattern="git show \"\$BASE_SHA:.github/scripts/check-branch-guard.sh\" > \"\$TRUSTED_CHECK\""
+trusted_run_pattern="\"\$RUNNER_TEMP/check-branch-guard.sh\""
+grep -Fq "$base_load_pattern" "$WORKFLOW" \
+  || fail "workflow 未從 base SHA 載入可信腳本"
+grep -Fq "$trusted_run_pattern" "$WORKFLOW" \
+  || fail "workflow 未執行 runner 暫存目錄內的可信副本"
+if grep -Eq '^[[:space:]]+\.github/scripts/check-branch-guard\.sh([[:space:]]|$)' "$WORKFLOW"; then
+  fail "workflow 不得直接執行 PR checkout 內的腳本"
+fi
+echo "✅ trusted base script boundary"
+
+echo "✅ branch guard regression tests passed"

--- a/.github/scripts/test-branch-guard.sh
+++ b/.github/scripts/test-branch-guard.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHECK="$SCRIPT_DIR/check-branch-guard.sh"
-WORKFLOW="$SCRIPT_DIR/../workflows/branch-guard.yml"
+ENFORCEMENT_WORKFLOW="$SCRIPT_DIR/../workflows/branch-guard.yml"
+REGRESSION_WORKFLOW="$SCRIPT_DIR/../workflows/branch-guard-regression.yml"
 
 fail() {
   echo "❌ $1"
@@ -44,37 +45,66 @@ output="$(HEAD="feat/large-pr" BASE="main" CHANGED=61 "$CHECK" 2>&1)" || fail "6
 echo "✅ 61 files warning/pass"
 
 job_section() {
-  local job="$1"
+  local workflow="$1" job="$2"
   awk -v header="  $job:" '
     $0 == header { inside = 1 }
     inside && $0 != header && $0 ~ /^  [[:alnum:]_-]+:$/ { exit }
     inside { print }
-  ' "$WORKFLOW"
+  ' "$workflow"
 }
 
-guard_job="$(job_section guard)"
-regression_job="$(job_section regression)"
+[[ -f "$REGRESSION_WORKFLOW" ]] || fail "缺少獨立 regression workflow"
 
-base_load_pattern="git show \"\$BASE_SHA:.github/scripts/check-branch-guard.sh\" > \"\$TRUSTED_CHECK\""
-trusted_run_pattern="\"\$RUNNER_TEMP/check-branch-guard.sh\""
-grep -Fq "$base_load_pattern" <<< "$guard_job" \
-  || fail "workflow 未從 base SHA 載入可信腳本"
-grep -Fq "$trusted_run_pattern" <<< "$guard_job" \
-  || fail "workflow 未執行 runner 暫存目錄內的可信副本"
+guard_job="$(job_section "$ENFORCEMENT_WORKFLOW" guard)"
+regression_job="$(job_section "$REGRESSION_WORKFLOW" regression)"
+
+grep -Eq '^  pull_request_target:' "$ENFORCEMENT_WORKFLOW" \
+  || fail "enforcement workflow 必須由 pull_request_target 的 trusted definition 執行"
+if grep -Eq '^  pull_request:' "$ENFORCEMENT_WORKFLOW"; then
+  fail "enforcement workflow 不得使用 PR 可修改 definition 的 pull_request event"
+fi
+grep -Eq '^permissions: \{\}$' "$ENFORCEMENT_WORKFLOW" \
+  || fail "enforcement workflow 預設 permissions 必須為空"
+grep -Fq 'contents: read' <<< "$guard_job" \
+  || fail "production guard 只能取得 checkout 所需的 contents: read"
+trusted_ref_pattern="ref: \${{ github.event.repository.default_branch }}"
+grep -Fq "$trusted_ref_pattern" <<< "$guard_job" \
+  || fail "production guard 必須只 checkout trusted default branch"
+grep -Fq 'persist-credentials: false' <<< "$guard_job" \
+  || fail "production guard checkout 不得保留 credentials"
+grep -Fq 'run: .github/scripts/check-branch-guard.sh' <<< "$guard_job" \
+  || fail "production guard 未執行 trusted default-branch checker"
 if grep -Fq '.github/scripts/test-branch-guard.sh' <<< "$guard_job"; then
   fail "production guard job 不得執行 PR checkout 內的測試"
 fi
-echo "✅ trusted base script boundary"
+if grep -Eq '(pull_request\.head\.sha|github\.head_ref)' <<< "$guard_job"; then
+  fail "production guard 不得 checkout PR head"
+fi
+if grep -Eq '(pull_request\.head\.sha|github\.head_ref|secrets\.|GITHUB_TOKEN|pull-requests:|issues:|contents: write)' "$ENFORCEMENT_WORKFLOW"; then
+  fail "production guard 不得取得不必要的 token、secret 或 write permissions"
+fi
+[[ "$(grep -Ec 'uses: actions/checkout@' "$ENFORCEMENT_WORKFLOW")" -eq 1 ]] \
+  || fail "enforcement workflow 只能 checkout 一次 trusted default branch"
+[[ "$(grep -Ec '^[[:space:]]+run:' "$ENFORCEMENT_WORKFLOW")" -eq 1 ]] \
+  || fail "enforcement workflow 只能執行 trusted checker"
+echo "✅ trusted enforcement boundary"
 
 [[ -n "$regression_job" ]] || fail "workflow 缺少 regression job"
+grep -Eq '^  pull_request:' "$REGRESSION_WORKFLOW" \
+  || fail "regression workflow 必須只在 pull_request context 執行 PR tests"
+grep -Eq '^permissions: \{\}$' "$REGRESSION_WORKFLOW" \
+  || fail "regression workflow 預設 permissions 必須為空"
 grep -Fq 'permissions: {}' <<< "$regression_job" \
   || fail "regression job 必須使用 permissions: {}"
 grep -Fq 'persist-credentials: false' <<< "$regression_job" \
   || fail "regression checkout 不得保留 credentials"
 grep -Fq 'run: .github/scripts/test-branch-guard.sh' <<< "$regression_job" \
   || fail "regression job 未執行 PR 版本測試"
-if grep -Eq '(secrets\.|GITHUB_TOKEN|permissions:[[:space:]]*$)' <<< "$regression_job"; then
+if grep -Eq '(secrets\.|GITHUB_TOKEN|permissions:[[:space:]]*$)' "$REGRESSION_WORKFLOW"; then
   fail "regression job 不得取得 secrets、token 或額外 permissions"
+fi
+if grep -Fq 'name: Branch flow rules' <<< "$regression_job"; then
+  fail "regression check 不得與 required enforcement check 同名"
 fi
 echo "✅ tokenless regression job contract"
 

--- a/.github/workflows/branch-guard-regression.yml
+++ b/.github/workflows/branch-guard-regression.yml
@@ -1,0 +1,28 @@
+name: Branch Guard Regression
+
+# This workflow intentionally runs pull-request code. It is isolated from the
+# required enforcement workflow and receives no repository permissions.
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/check-branch-guard.sh'
+      - '.github/scripts/test-branch-guard.sh'
+      - '.github/workflows/branch-guard.yml'
+      - '.github/workflows/branch-guard-regression.yml'
+
+permissions: {}
+
+jobs:
+  regression:
+    name: Branch guard regression (untrusted PR)
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Checkout pull request for tests
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run branch guard regression tests
+        run: .github/scripts/test-branch-guard.sh

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,78 +1,32 @@
 name: Branch Guard
 
-# 分支流程守門：無效 PR 有一半是流程錯（base 錯、分支名不合規），
-# 10 行 CI 規則的投報率高過任何檢索系統。
+# Enforcement runs from the default branch's trusted workflow definition.
+# Never checkout or execute pull-request code in this workflow.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+permissions: {}
+
 jobs:
-  regression:
-    name: Branch guard regression tests
-    runs-on: ubuntu-latest
-    permissions: {}
-
-    steps:
-      # This job intentionally runs pull-request code, so it must remain
-      # tokenless and must not persist checkout credentials.
-      - name: Checkout pull request for tests
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Run branch guard regression tests
-        run: .github/scripts/test-branch-guard.sh
-
   guard:
     name: Branch flow rules
     runs-on: ubuntu-latest
     permissions:
+      # Required only while actions/checkout reads the trusted default branch.
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout trusted default branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
           persist-credentials: false
-
-      - name: Load trusted branch guard
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          TRUSTED_CHECK="$RUNNER_TEMP/check-branch-guard.sh"
-
-          if git cat-file -e "$BASE_SHA:.github/scripts/check-branch-guard.sh" 2>/dev/null; then
-            git show "$BASE_SHA:.github/scripts/check-branch-guard.sh" > "$TRUSTED_CHECK"
-          else
-            # Bootstrap only: the base revision predates the checked-in script.
-            # Keep this fallback in the trusted workflow instead of executing the
-            # pull request's checkout copy.
-            cat > "$TRUSTED_CHECK" <<'BRANCH_GUARD'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          BRANCH_RE='^(feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate)/.+'
-          if [[ ! "$HEAD" =~ $BRANCH_RE ]]; then
-            echo "::error::分支名 '$HEAD' 不符慣例（type/description，type ∈ feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate）"
-            exit 1
-          fi
-          if [[ "$BASE" != "main" ]]; then
-            echo "::error::PR base 是 '$BASE'，monorepo 的 PR 應以 main 為 base"
-            exit 1
-          fi
-          if (( CHANGED > 60 )); then
-            echo "::warning::此 PR 變更 $CHANGED 個檔案（>60）——請確認沒有帶入非本題檔案或 base 選錯"
-          fi
-          echo "✅ branch guard passed: $HEAD → $BASE ($CHANGED files)"
-          BRANCH_GUARD
-          fi
-
-          chmod +x "$TRUSTED_CHECK"
 
       - name: Check branch name and base
         env:
-          HEAD: ${{ github.head_ref }}
-          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.event.pull_request.head.ref }}
+          BASE: ${{ github.event.pull_request.base.ref }}
           CHANGED: ${{ github.event.pull_request.changed_files }}
-        run: |
-          "$RUNNER_TEMP/check-branch-guard.sh"
+        run: .github/scripts/check-branch-guard.sh

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -7,6 +7,22 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
+  regression:
+    name: Branch guard regression tests
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      # This job intentionally runs pull-request code, so it must remain
+      # tokenless and must not persist checkout credentials.
+      - name: Checkout pull request for tests
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run branch guard regression tests
+        run: .github/scripts/test-branch-guard.sh
+
   guard:
     name: Branch flow rules
     runs-on: ubuntu-latest
@@ -18,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Load trusted branch guard
         env:

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,61 @@
+name: Branch Guard
+
+# 分支流程守門：無效 PR 有一半是流程錯（base 錯、分支名不合規），
+# 10 行 CI 規則的投報率高過任何檢索系統。
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  guard:
+    name: Branch flow rules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Load trusted branch guard
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          TRUSTED_CHECK="$RUNNER_TEMP/check-branch-guard.sh"
+
+          if git cat-file -e "$BASE_SHA:.github/scripts/check-branch-guard.sh" 2>/dev/null; then
+            git show "$BASE_SHA:.github/scripts/check-branch-guard.sh" > "$TRUSTED_CHECK"
+          else
+            # Bootstrap only: the base revision predates the checked-in script.
+            # Keep this fallback in the trusted workflow instead of executing the
+            # pull request's checkout copy.
+            cat > "$TRUSTED_CHECK" <<'BRANCH_GUARD'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          BRANCH_RE='^(feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate)/.+'
+          if [[ ! "$HEAD" =~ $BRANCH_RE ]]; then
+            echo "::error::分支名 '$HEAD' 不符慣例（type/description，type ∈ feat|fix|refactor|perf|test|docs|chore|ci|build|hotfix|release|auto|claude|codex|dependabot|renovate）"
+            exit 1
+          fi
+          if [[ "$BASE" != "main" ]]; then
+            echo "::error::PR base 是 '$BASE'，monorepo 的 PR 應以 main 為 base"
+            exit 1
+          fi
+          if (( CHANGED > 60 )); then
+            echo "::warning::此 PR 變更 $CHANGED 個檔案（>60）——請確認沒有帶入非本題檔案或 base 選錯"
+          fi
+          echo "✅ branch guard passed: $HEAD → $BASE ($CHANGED files)"
+          BRANCH_GUARD
+          fi
+
+          chmod +x "$TRUSTED_CHECK"
+
+      - name: Check branch name and base
+        env:
+          HEAD: ${{ github.head_ref }}
+          BASE: ${{ github.base_ref }}
+          CHANGED: ${{ github.event.pull_request.changed_files }}
+        run: |
+          "$RUNNER_TEMP/check-branch-guard.sh"

--- a/docs/automation/branch-guard.md
+++ b/docs/automation/branch-guard.md
@@ -1,0 +1,24 @@
+# Root Branch Guard
+
+`.github/workflows/branch-guard.yml` 檢查所有以 daodao monorepo root
+為目標的 pull request。
+
+## 規則
+
+- Head branch 必須使用 `type/description` 前綴，例如 `feat/`、`fix/`、
+  `docs/`、`chore/`、`ci/`、`build/`、`auto/`、`claude/` 或 `codex/`。
+- PR base 必須是 `main`。
+- 變更超過 60 個檔案時顯示警告，但不會只因檔案數量而擋下 PR。
+
+Workflow 會從 PR 的 base SHA 讀取 `.github/scripts/check-branch-guard.sh`
+到 runner 暫存目錄後執行，避免執行 PR 可修改的 checkout 腳本。若 base revision
+還沒有該腳本，則使用 workflow 內建的可信 bootstrap 規則。
+
+## 啟用守門
+
+Workflow 本身只會回報 check。Repository 管理員仍需在 `main` branch protection
+或 ruleset 將 `Branch flow rules` 設成 required status check，才會成為實際的
+merge gate。
+
+本 PR 只涵蓋 root monorepo。各 sub-repo 有不同的 `dev`／`main` 政策，
+需要各自的 workflow 與 PR。

--- a/docs/automation/branch-guard.md
+++ b/docs/automation/branch-guard.md
@@ -10,18 +10,36 @@
 - PR base 必須是 `main`。
 - 變更超過 60 個檔案時顯示警告，但不會只因檔案數量而擋下 PR。
 
-Workflow 會從 PR 的 base SHA 讀取 `.github/scripts/check-branch-guard.sh`
-到 runner 暫存目錄後執行，避免執行 PR 可修改的 checkout 腳本。若 base revision
-還沒有該腳本，則使用 workflow 內建的可信 bootstrap 規則。
+Enforcement workflow 使用 `pull_request_target`，因此 workflow definition 來自
+repository 的 trusted default branch。它只 checkout default branch 並執行其中的
+`.github/scripts/check-branch-guard.sh`，不會 checkout 或執行 PR code；checkout
+所需的 `contents: read` token 也不會持久化到 git config。
 
-另有獨立 regression job 執行 PR 版本的測試；該 job 使用 `permissions: {}`，
-checkout 也不保留 credentials，因此不會把 token 或 secrets 暴露給 PR 程式碼。
+`.github/workflows/branch-guard-regression.yml` 是獨立的 PR regression workflow。
+它執行 PR 版本的測試，但使用 `permissions: {}`、不保留 checkout credentials，
+且 check 名稱不是 `Branch flow rules`。不可把這個 untrusted regression check
+設成 enforcement workflow 的替代品。
 
 ## 啟用守門
 
-Workflow 本身只會回報 check。Repository 管理員仍需在 `main` branch protection
-或 ruleset 將 `Branch flow rules` 設成 required status check，才會成為實際的
-merge gate。
+Workflow merge 到 default branch 後，Organization 管理員需建立 branch ruleset：
+
+1. 到 organization **Settings → Rules → Rulesets → New branch ruleset**。
+2. Repository targeting 選擇 `daodaoedu/daodao`。
+3. Target branches 選 **Include all branches**，不可只選 `main`；否則以 `dev`
+   或其他 branch 為 base 的錯誤 PR 不受規則約束。
+4. 啟用 **Require workflows to pass before merging**，source repository 選
+   `daodaoedu/daodao`，workflow 選 default branch 上的
+   `.github/workflows/branch-guard.yml`。
+5. 將 Enforcement status 設為 **Active**，儲存後用兩個測試 PR 核驗：
+   `feature/invalid → main` 與 `feat/valid → dev` 都必須被 required workflow 擋下。
+
+這裡要求的是由 source repository + workflow file 識別的 **required workflow**，
+不是只按 job 名稱比對的 required status check；後者可能被 PR 內另一個 workflow
+產生同名 check 冒充。GitHub 官方設定說明見
+[Require workflows to pass before merging](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-workflows-to-pass-before-merging)
+與
+[建立 organization ruleset](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/creating-rulesets-for-repositories-in-your-organization)。
 
 本 PR 只涵蓋 root monorepo。各 sub-repo 有不同的 `dev`／`main` 政策，
 需要各自的 workflow 與 PR。

--- a/docs/automation/branch-guard.md
+++ b/docs/automation/branch-guard.md
@@ -14,6 +14,9 @@ Workflow 會從 PR 的 base SHA 讀取 `.github/scripts/check-branch-guard.sh`
 到 runner 暫存目錄後執行，避免執行 PR 可修改的 checkout 腳本。若 base revision
 還沒有該腳本，則使用 workflow 內建的可信 bootstrap 規則。
 
+另有獨立 regression job 執行 PR 版本的測試；該 job 使用 `permissions: {}`，
+checkout 也不保留 credentials，因此不會把 token 或 secrets 暴露給 PR 程式碼。
+
 ## 啟用守門
 
 Workflow 本身只會回報 check。Repository 管理員仍需在 `main` branch protection


### PR DESCRIPTION
## Summary
- add a root branch flow guard that runs from trusted default-branch workflow code using `pull_request_target`
- split untrusted PR regression checks into a separate tokenless workflow
- document the required organization ruleset setup for enforcing the workflow on all target branches

## Verification
- `bash .github/scripts/test-branch-guard.sh`
- `bash -n` / ShellCheck for branch guard scripts
- YAML parse for `branch-guard.yml` and `branch-guard-regression.yml`
- workflow `run` blocks checked with `bash -n`
- `git diff --check`

## Admin follow-up
After merge, enable an Organization ruleset with target branches set to Include all branches and require `.github/workflows/branch-guard.yml` to pass before merging. A same-name required status check is not enough for wrong-base PRs.
