### PR TITLE
fix(code-review): 修復模型輸出格式漂移，驗證失敗時降級為警告

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -206,12 +206,45 @@ jobs:
               next
             }
             { print }
-          ' "$RUNNER_TEMP/review-body.opencc" > "$RUNNER_TEMP/review-body.normalized"
+          ' "$RUNNER_TEMP/review-body.opencc" > "$RUNNER_TEMP/review-body.tabled"
+
+          # 小模型常見的格式漂移自動修復：嚴重度中文（高/中/低）、檔案欄的
+          # 行號範圍（path:12-34）、L 前綴（path:L12）、cell 內多餘空白。
+          REPAIR_INPUT_FILE="$RUNNER_TEMP/review-body.tabled" node -e '
+            const fs = require("fs");
+            const body = fs.readFileSync(process.env.REPAIR_INPUT_FILE, "utf8");
+            const repaired = body.split("\n").map((line) => {
+              if (!line.startsWith("|")) return line;
+              const cells = line.split("|");
+              if (cells.length < 6) return line;
+              const severity = cells[1].trim();
+              if (severity === "嚴重度" || /^-+$/.test(severity)) return line;
+              cells[1] = ` ${severity
+                .replace(/高|嚴重/, "High")
+                .replace(/中/, "Medium")
+                .replace(/低|輕微/, "Low")} `;
+              const rawFile = cells[2].trim();
+              const hadBackticks = /^`.*`$/.test(rawFile);
+              const file = rawFile
+                .replace(/^`|`$/g, "")
+                .replace(/\s+/g, "")
+                .replace(/:L(\d)/, ":$1")
+                .replace(/:(\d+)[-–—,~](\d+)$/, ":$1");
+              cells[2] = hadBackticks ? ` \`${file}\` ` : ` ${file} `;
+              return cells.join("|");
+            }).join("\n");
+            fs.writeFileSync(process.env.REPAIR_INPUT_FILE.replace(/tabled$/, "normalized"), repaired);
+          '
 
           BODY="$(cat "$RUNNER_TEMP/review-body.normalized")"
           if ! is_valid_review "$BODY"; then
-            echo "::error::Normalized Workers AI review has an invalid schema"
-            exit 1
+            # 模型輸出不合 schema 是模型的問題，不是 PR 的問題：
+            # 降級成 warning、跳過留言，不讓 check 變紅。
+            echo "::warning::Normalized Workers AI review has an invalid schema; skipping review comment"
+            echo "::group::Invalid review body"
+            printf '%s\n' "$BODY"
+            echo "::endgroup::"
+            exit 0
           fi
 
           if ! printf '%s\n' "$HEAD_SHA" | grep -Eq '^[0-9a-f]{40}$'; then


### PR DESCRIPTION
## Why is this necessary?

- 當模型輸出格式發生漂移時，原本的嚴格 schema 驗證會導致系統無法正常運作。
- 為了避免因為格式微小差異而中斷程式流程，需要提供更彈性的錯誤處理機制。
- 原本的驗證失敗處理方式可能過於嚴苛，無法在資料不完整時提供有用的除錯資訊。

## How does it address?

- 將 schema 驗證失敗的處理方式從錯誤降級為警告，確保程式能繼續執行。
- 新增自動修復模型輸出格式漂移的功能，減少人工介入的需求。
- 在驗證失敗時改為顯示警告訊息，讓開發者能夠追蹤潛在的格式問題而不中斷流程。