### PR TITLE
fix(ci): 修正新版 gh CLI 指令衝突問題

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -274,8 +274,11 @@ jobs:
         run: |
           BODY="$(cat "$RUNNER_TEMP/review-body.md")"
           HEAD_MARKER="<!-- daodao-ai-code-review-head:$HEAD_SHA -->"
+          # 新版 gh CLI 不允許 --slurp 與 --jq 併用，改用管線交給 jq；
+          # 順便用 --arg 傳 marker，避免 shell 內插進 jq 程式。
           COMMENTS="$(gh api --paginate --slurp "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq "add | [.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$HEAD_MARKER\")))]")"
+            | jq --arg marker "$HEAD_MARKER" \
+              'add | [.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))]')"
           EXISTING=$(printf '%s' "$COMMENTS" | jq 'length')
 
           if [ "$EXISTING" -gt "0" ]; then


### PR DESCRIPTION
## Why is this necessary?

- 新版 GitHub CLI (gh) 對 `--slurp` 與 `--jq` 參數的併用支援發生變更，導致指令執行被拒絕。
- 原本在管線中直接使用 `gh api --slurp --jq` 的方式無法在最新版本的 CLI 中正常運作。
- 為了確保 CI/CD 管線在升級後仍能正常解析 code review 資料，必須修正指令參數的使用方式。

## How does it address?

- 將原本嘗試在 `gh api` 指令中直接處理 JSON 資料的邏輯，改為先透過 `gh api --slurp` 取得原始資料。
- 透過 `jq` 指令在後端處理 JSON 資料的過濾與轉換，解決新版 CLI 對參數組合的限制。
- 調整了指令的執行流程，將資料解析的責任從 CLI 工具轉移至標準的 JSON 處理工具，確保相容性。