### PR TITLE
feat(pipeline): 移除 Ready for Dev 自動派工的閘門

### DIFF
--- a/.claude/skills/gh-card/SKILL.md
+++ b/.claude/skills/gh-card/SKILL.md
@@ -33,7 +33,7 @@ description: 在 daodaoedu/daodao 建立中央 feature issue 並掛上 org Plann
 - **Status**：預設 `Todo`（安全；`Ready for Dev` 才會被 Routine A 撿走）
 - **Target repo(s)**：提到了哪些 sub-repo → `repo:<name>` label
 - **Scope**：根據複雜度估計 → `scope:XS|S|M|L` label
-- **Auto mode**：`auto` + `auto:plan-only`（保守預設）或 `auto:auto-pr`；不加 `auto` = 純人工卡
+- **Auto mode**：預設 plan-only（不用掛 label）；要全自動開 PR 掛 `auto:auto-pr`；不想被 pipeline 碰掛 `human-driving`
 
 ### Step 2：互動確認
 
@@ -45,7 +45,7 @@ description: 在 daodaoedu/daodao 建立中央 feature issue 並掛上 org Plann
 Title:        {推斷值}
 Status:       Todo ← 預設（改 "Ready for Dev" 才會進 pipeline）
 Labels:       {scope:M, repo:daodao-f2e, ...}
-Auto:         （不加）← 預設；要進自動 pipeline 需 auto + auto:plan-only|auto-pr
+Auto:         plan-only ← 預設（Ready for Dev 即派工）；auto:auto-pr = 全自動開 PR；human-driving = 退出 pipeline
 Body:         {摘要}
 ```
 
@@ -67,7 +67,7 @@ gh project item-edit --project-id PVT_kwDOBTLl0c4Bgxef --id <item-id> \
 ### Step 4：回報
 
 - Issue URL + board 連結
-- 若 Status=`Ready for Dev` 且有 `auto` label → 提示「下次 Routine A 執行時（最慢 1 小時）會自動 dispatch 到 sub-repo」
+- 若 Status=`Ready for Dev`（且無 `human-driving`）→ 提示「下次 Routine A 執行時（最慢 1 小時）會自動 dispatch 到 sub-repo」
 - 若無 spec（issue body 沒有 OpenSpec change 連結、沒有 Acceptance Criteria）→ 提示「Routine A 會標 `needs-spec`，建議先跑 `prd-generation` / `openspec-ff-change` 產 spec」
 
 ---
@@ -101,6 +101,6 @@ gh project item-edit --project-id PVT_kwDOBTLl0c4Bgxef --id <item-id> \
 
 - Status 預設 `Todo`（安全），避免意外觸發 dispatch
 - Scope 預設 `M`（保守）
-- Auto mode 預設 `auto:plan-only`；**沒有 `auto` label 的卡 Routine A 永遠不碰**
+- Auto mode 預設 plan-only；**Ready for Dev 即派工，掛 `human-driving` 的卡 Routine A 永遠不碰**
 - 高風險 repo（`daodao-storage`、`daodao-infra`）：建立時提示「此 repo 為高風險，pipeline 強制 plan-only」
 - Priority field 目前沒有 options，暫不設定

--- a/.claude/skills/gh-pipeline/SKILL.md
+++ b/.claude/skills/gh-pipeline/SKILL.md
@@ -29,13 +29,14 @@ Monorepo root: `/Users/xiaoxu/Projects/daodao`
 
 Script 行為（判斷邏輯在 `bin/pipeline/lib.ts`，有 vitest 測試）：
 1. `.automation-paused` 存在 → exit 0
-2. 掃 board `Status=Ready for Dev`，issue 需有 `auto` label、無 `dispatched`/`needs-spec`/`human-driving`、state open
+2. 掃 board `Status=Ready for Dev`，issue 需無 `dispatched`/`needs-spec`/`human-driving`、state open（Ready for Dev 即派工；`human-driving` 是退出閥）
 3. **Spec gate**：body 的 `OpenSpec: <slug>` 註記 + `openspec/changes/<slug>/tasks.md` 存在，否則標 `needs-spec` + comment
 4. **規則化拆卡**：tasks.md 每個 `## section` 一張鏡像 issue；target repo 依「section 標題 → task 內文提及的 sub-repo 名稱 → 卡片唯一 `repo:*` label」判定，判不出 → `needs-spec` 退回
 5. 鏡像 issue 掛 sub-issue、中央卡 `dispatched` + comment、board → In Progress；每輪最多 3 張卡
 6. 冪等：以鏡像 title + body 的 `Parent:` 反查去重，部分失敗不標 `dispatched`，下輪續跑
 
 高風險 repo（`daodao-storage` / `daodao-infra`）：鏡像 issue 一律 `auto:plan-only`，不論中央卡 label。
+執行模式：中央卡有 `auto:auto-pr` → 鏡像 issue 直接開 code PR；否則一律 plan-only。
 
 ---
 

--- a/bin/pipeline/dispatch.ts
+++ b/bin/pipeline/dispatch.ts
@@ -10,7 +10,8 @@
  *
  * Flow (hourly via .github/workflows/pipeline-dispatch.yml):
  *   1. List board items with Status="Ready for Dev" on the central repo
- *   2. Gate: issue open, has `auto` label, no dispatched/needs-spec/human-driving
+ *   2. Gate: issue open, no dispatched/needs-spec/human-driving (opt-out via `human-driving`;
+ *      mode defaults to plan-only unless the card carries `auto:auto-pr`)
  *   3. Spec gate: body has "OpenSpec: <slug>" and openspec/changes/<slug>/tasks.md exists
  *   4. Rule-based split: each tasks.md "## section" → one mirror issue in its sub-repo
  *   5. Mirror issues become native sub-issues; central card gets `dispatched` + comment;
@@ -87,10 +88,6 @@ function main(): void {
 
     const issue = getIssue(CENTRAL_REPO, item.issueNumber!);
     if (!issue || issue.state !== "OPEN") continue;
-    if (!issue.labels.includes("auto")) {
-      log(`#${issue.number} has no auto label — skip`);
-      continue;
-    }
     if (issue.labels.some((l) => ["dispatched", "needs-spec", "human-driving"].includes(l))) {
       log(`#${issue.number} labeled ${issue.labels.join(",")} — skip`);
       continue;

--- a/bin/routine-dispatch/state-store.json
+++ b/bin/routine-dispatch/state-store.json
@@ -1,5 +1,5 @@
 {
-  "last_scan_at": "2026-08-23T11:38:15.000Z",
+  "last_scan_at": "",
   "last_dispatch_run_at": "",
   "pause_reason": "",
   "token_usage_by_issue": {},

--- a/docs/automation/github-pipeline.md
+++ b/docs/automation/github-pipeline.md
@@ -14,7 +14,7 @@
   - Routine A 把 Ready for Dev 的中央卡 dispatch 成 sub-repo **鏡像 issue**（掛 sub-issue）
   - Routine B 對鏡像 issue 做 plan / code / 開 PR
   - Routine C 把 merged PR 的完成狀態回寫 board
-- **兩道閘門**：board `Status=Ready for Dev` **且** 中央 issue 有 `auto` label，缺一不 dispatch
+- **單一閘門**：board `Status=Ready for Dev` 即派工（Ready for Dev = 派工佇列）；不想被 pipeline 碰的卡掛 `human-driving` 退出
 - **Spec gate**：中央 issue body 必須註記 `OpenSpec: openspec/changes/{slug}/` 且該 change 有 tasks.md，否則標 `needs-spec` 退回
 
 ## 全流程圖
@@ -25,11 +25,11 @@ flowchart TD
         PRD["docs/product PRD/FRD<br/>（prd-generation skill）"]
         SPEC["OpenSpec change<br/>openspec/changes/&lt;slug&gt;/<br/>（openspec-ff-change）"]
         CARD["gh-card skill 開卡<br/>daodaoedu/daodao issue<br/>→ 掛 Planning board"]
-        READY{"人工確認：<br/>Status → Ready for Dev<br/>+ auto label"}
+        READY{"人工確認：<br/>Status → Ready for Dev"}
     end
 
     subgraph routineA["Routine A（Actions script・每小時）Board → Dispatch"]
-        SCAN_A["掃 board<br/>Status=Ready for Dev + auto<br/>−dispatched −needs-spec"]
+        SCAN_A["掃 board<br/>Status=Ready for Dev<br/>−dispatched −needs-spec −human-driving"]
         GATE{"spec gate：<br/>OpenSpec 註記存在？"}
         NEEDSPEC["標 needs-spec + comment<br/>退回人工補 spec"]
         MIRROR["拆 tasks → sub-repo 開鏡像 issue<br/>（auto + scope + auto-mode labels）<br/>掛為 sub-issue"]
@@ -70,7 +70,7 @@ flowchart TD
 ```mermaid
 stateDiagram-v2
     [*] --> Todo : gh-card 開卡
-    Todo --> ReadyForDev : 人工：spec 完成<br/>設 Status + auto label
+    Todo --> ReadyForDev : 人工：spec 完成<br/>設 Status
     ReadyForDev --> ReadyForDev : Routine A 標 needs-spec<br/>（spec gate 未過，退回）
     ReadyForDev --> InProgress : Routine A dispatch<br/>（鏡像 issue + sub-issues）
     InProgress --> InProgress : Routine B plan/code/PR<br/>Routine C 回報 n/m
@@ -78,9 +78,9 @@ stateDiagram-v2
     Done --> [*] : product 驗收<br/>手動 close issue
 
     note right of ReadyForDev
-        兩道閘門：
+        單一閘門：
         Status=Ready for Dev
-        AND auto label
+        （human-driving 可退出）
     end note
 ```
 
@@ -97,7 +97,7 @@ sequenceDiagram
     participant RC as Routine C
 
     P->>C: gh-card 開卡（附 FRD/OpenSpec）
-    P->>B: Status → Ready for Dev + auto label
+    P->>B: Status → Ready for Dev
     A->>B: 每小時掃 Ready for Dev
     A->>C: spec gate 檢查
     alt 無 spec
@@ -122,8 +122,8 @@ sequenceDiagram
 
 | Label | 誰加 | 意義 |
 |---|---|---|
-| `auto` | 人工（gh-card） | 允許進 pipeline（第二道閘門） |
-| `auto:plan-only` / `auto:auto-pr` | 人工 | 鏡像 issue 繼承的執行模式 |
+| `human-driving` | 人工 | 退出 pipeline（Ready for Dev 也不派工） |
+| `auto:plan-only` / `auto:auto-pr` | 人工 | 執行模式；未掛一律 plan-only |
 | `scope:XS/S/M/L` | 人工 | 複雜度，決定 agentic flow |
 | `repo:<sub-repo>` | 人工 | 目標 repo 標注（board 篩選用） |
 | `dispatched` | Routine A | 已 dispatch，避免重複處理 |


### PR DESCRIPTION
## Why is this necessary?

- 移除自動派工閘門以簡化流程，減少不必要的自動化步驟。
- 讓開發者能更明確地控制何時觸發派工動作，避免誤觸。
- 減少 pipeline 中不必要的複雜度，提升整體執行效率。

## How does it address?

- 移除了名為 "auto label 閘門" 的功能，該功能原本會在 Ready for Dev 狀態時自動觸發派工。
- 讓派工流程回歸手動控制，不再依賴自動化閘門機制。